### PR TITLE
Firefox extension initial updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
 		"clean": "rm -rf .parcel-cache/* build/*",
 		"prod:css": "yarn tailwindcss -i ./src/css/base.css -c ./tailwind.config.js -o ./src/css/tailwind.css",
 		"prod:parcel": "yarn parcel build src/manifest.json --target prod --dist-dir ./build --no-source-maps",
-		"release": "./scripts/release.zsh"
+		"release": "./scripts/release.zsh",
+		"build:ff": "yarn clean && NODE_ENV=production yarn prod:css && yarn prebuild:firefox && yarn prod:parcel:firefox && yarn postbuild:firefox",
+		"prod:parcel:firefox": "yarn parcel build src/manifest.json --target prod-firefox --dist-dir ./build --no-source-maps",
+		"prebuild:firefox": "mv src/manifest.json src/manifest-chrome.json && mv src/manifest-firefox.json src/manifest.json",
+		"postbuild:firefox": "mv src/manifest.json src/manifest-firefox.json && mv src/manifest-chrome.json src/manifest.json"
 	},
 	"browserslist": [
 		"since 2017-06"
@@ -23,7 +27,8 @@
 				"inlineSources": true
 			}
 		},
-		"prod": {}
+		"prod": {},
+		"prod-firefox": {}
 	},
 	"devDependencies": {
 		"@babel/core": "^7.12.0",

--- a/scripts/release.zsh
+++ b/scripts/release.zsh
@@ -12,6 +12,12 @@ yarn build;
 cd build/prod
 zip -r ../../builds/build-$TAG.zip *;
 cd ../..
+# production firefox build
+yarn build:ff;
+# zip firefox
+cd build/prod-firefox
+zip -r ../../builds/build-firefox-$TAG.zip *;
+cd ../..
 # commit changes
 git add package.json;
 git add src/manifest.json;

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -19,6 +19,9 @@ html {
 
 body {
   color: #000;
+  width: 500px !important;
+  font-size: 9pt;
+  overflow: hidden;
 }
 
 .max-result {

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,0 +1,90 @@
+{
+  "manifest_version": 3,
+  "name": "Board Game Arena (BGA) Extension",
+  "short_name": "BGA Extension",
+  "version": "1.9.37",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "options_ui": {
+    "page": "options.html"
+  },
+  "default_locale": "en",
+  "description": "__MSG_ext_description__",
+  "icons": {
+    "16": "img/icon-16.png",
+    "48": "img/icon-48.png",
+    "128": "img/icon-128.png"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://boardgamearena.com/*",
+        "https://studio.boardgamearena.com/*"
+      ],
+      "run_at": "document_start",
+      "js": [
+        "content.js"
+      ],
+      "all_frames": true
+    },
+    {
+      "matches": [
+        "https://forum.boardgamearena.com/*"
+      ],
+      "run_at": "document_start",
+      "js": [
+        "contentForum.js"
+      ],
+      "all_frames": true
+    }
+  ],
+  "author": "Flavien Busseuil & Christophe Delaforge",
+  "homepage_url": "https://github.com/FlavienBusseuil/bga-chrome-extension",
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
+  "host_permissions": [
+    "https://*.boardgamearena.com/*/*",
+    "https://*.boardgamearena.net/*/*"
+  ],
+  "permissions": [
+    "alarms",
+    "storage",
+    "declarativeNetRequest"
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "img/anim-*.png",
+        "img/loading.gif",
+        "img/icon-48.png",
+        "img/icon-grey.png",
+        "css/dark_theme/*.css",
+        "img/dark_theme/background.jpg",
+        "img/dark_theme/forum/*.png",
+        "img/dark_theme/forum/*.gif",
+        "img/dark_theme/forum/smilies/*.gif",
+        "img/dark_theme/tooltip/*.png",
+        "css/light_theme/*.css",
+        "img/light_theme/background.jpg",
+        "js/homepage.js"
+      ],
+      "extension_ids": [
+        "*"
+      ],
+      "matches": [
+        "*://*/*"
+      ]
+    }
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "FlavienBusseuil-bgachromeextension@github.com",
+      "strict_min_version": "113.0"
+    }
+  }
+}


### PR DESCRIPTION
Hey there!

I took a stab at the updates required to get this extension running on Firefox. Firefox only needs a couple changes to the manifest and I also made some changes to package.json scripts to get it automated. I also added to the release.zsh file, but I haven't tested that part yet (it's just running the build and zipping to another builds zip).

Manifest changes per Firefox (compare manifest.json to manifest-firefox.json for a quick look):
Max length for name is 45 characters - I shortened it.
background.service_worker isn't supported, I used the Mozilla-favored background.scripts
Extension Id: For Manifestv3 Mozilla wants a unique id for the extension. (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings and https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/). This can be anything unique, probably should just be a guid, but they also support email formatted unique ids so I just popped in "FlavienBusseuil-bgachromeextension@github.com" - feel free to change this to anything unique or even the extension email address.

I checked the resulting build against the Mozilla developers addon validator tool here: https://addons.mozilla.org/en-US/developers/addon/validate and it passes with a few warnings about unsafe innerHtml setting. I then ran the extension on my machine in debugging mode and it appears to work but I don't use all the features myself so I could have missed something.

Feel free to use/start with this PR or otherwise just extract the relevant info to do it yourself. I hope this helps kickstart/progress the effort to get this working in Firefox. :)

Thanks!
-Matt (arrendek)