### PR TITLE
!important button colors overrides .disabled usage

### DIFF
--- a/src/css/dark_theme/common.css
+++ b/src/css/dark_theme/common.css
@@ -54,23 +54,27 @@
   background: linear-gradient(180deg, #84461f, #db661f)
 }
 
-.bgabutton_blue,
-.bga-button--blue {
-  background: linear-gradient(180deg, #0ba9b7, #248189) !important;
-}
+:not(.disabled) {
 
-.bgabutton_blue:hover,
-.bga-button--blue:hover,
-.notouch-device .bgabutton_blue:hover,
-.notouch-device .bga-button--blue:hover {
-  background: linear-gradient(180deg, #06d7ea, #248189) !important;
-}
+  .bgabutton_blue,
+  .bga-button--blue {
+    background: linear-gradient(180deg, #0ba9b7, #248189) !important;
+  }
 
-.bgabutton_blue:active,
-.notouch-device .bgabutton_blue:active,
-.bga-button--blue:active,
-.notouch-device .bga-button--blue:active {
-  background: linear-gradient(180deg, #248189, #0ba9b7) !important;
+  .bgabutton_blue:hover,
+  .bga-button--blue:hover,
+  .notouch-device .bgabutton_blue:hover,
+  .notouch-device .bga-button--blue:hover {
+    background: linear-gradient(180deg, #06d7ea, #248189) !important;
+  }
+
+  .bgabutton_blue:active,
+  .notouch-device .bgabutton_blue:active,
+  .bga-button--blue:active,
+  .notouch-device .bga-button--blue:active {
+    background: linear-gradient(180deg, #248189, #0ba9b7) !important;
+  }
+
 }
 
 /* Modales et popin */


### PR DESCRIPTION
BGA buttons should turn grey if disabled.  These rules with important colors are preventing that.  Solution: wrap in :not(.disabled)