### PR TITLE
Games In Progress New Option: More Colorful Table Tiles

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -400,6 +400,12 @@
 	"optionsInProgressMoreOff": {
 		"message": "'More friends' section hidden"
 	},
+	"optionsInProgressColorfulTablesOn": {
+		"message": "More colorful tables"
+	},
+	"optionsInProgressColorfulTablesOff": {
+		"message": "Default table colors"
+	},
 	"optionsHomeAdvancedOn": {
 		"message": "Advanced configuration"
 	},

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -400,6 +400,9 @@
 	"optionsInProgressMoreOff": {
 		"message": "Section 'Plus d'amis' cachée"
 	},
+	"optionsInProgressColorfulTables": {
+		"message": "Des tables plus colorées"
+	},
 	"optionsHomeAdvancedOn": {
 		"message": "Configuration avancée"
 	},

--- a/src/content.js
+++ b/src/content.js
@@ -284,6 +284,7 @@ document.addEventListener("bga_ext_update_config", (data) => {
 			document.documentElement.classList.contains("bgaext_gameinprogress")
 		) {
 			buildMainCss(config.getAllCss());
+			setInProgressTableStyle(config);
 		}
 	} else if (data.detail.key === "home") {
 		localStorage.removeItem("bga-homepage-newsfeed-slots");

--- a/src/css/colorfulTables.css
+++ b/src/css/colorfulTables.css
@@ -1,3 +1,96 @@
-body {
-	background: #ff0000 !important;
+html {
+	color-scheme: light;
+
+	&.darkmode {
+		color-scheme: dark;
+
+		& .bga-table-list-item {
+			/* Extension's current dark theme sets these with !important so changing values instead */
+			--dark-10: var(--gametile-border-color);
+			--dark-20: var(--gametile-surface-color);
+			--dark-40: var(--gametile-surface-color);
+			--light-50: var(--gametile-icon-color);
+		}
+	}
 }
+
+.bga-table-list-item {
+	--gametile-border-color: var(--gametile-type-color);
+	--gametile-color: light-dark(
+		hsl(from var(--gametile-type-color) h s calc(l - 15)),
+		hsl(from var(--gametile-type-color) h s calc(l + 25))
+	);
+	--gametile-icon-color: hsl(
+		from var(--gametile-type-color) h s calc(l + 15)
+	);
+	--gametile-surface-color: light-dark(
+		hsl(from var(--gametile-type-color) h s calc(l + 45)),
+		hsl(from var(--gametile-type-color) h s calc(l - 25))
+	);
+
+	&:has(> .bga-table-list-item__background[style$="rgb(64, 117, 158);"]) {
+		--gametile-type-color: rgb(64, 117, 158);
+	}
+	&:has(> .bga-table-list-item__background[style$="rgb(150, 171, 192);"]) {
+		--gametile-type-color: rgb(150, 171, 192);
+	}
+	&:has(> .bga-table-list-item__background[style$="rgb(88, 78, 161);"]) {
+		--gametile-type-color: rgb(88, 78, 161);
+	}
+	&:has(> .bga-table-list-item__background[style$="rgb(158, 154, 194);"]) {
+		--gametile-type-color: rgb(158, 154, 194);
+	}
+	&:has(> .bga-table-list-item__background[style$="rgb(143, 92, 167);"]) {
+		--gametile-type-color: rgb(143, 92, 167);
+	}
+
+	& .bga-table-list-item__background > div > .bga-table-list-item__main {
+		background-color: var(--gametile-surface-color);
+		border: 1px solid var(--gametile-border-color);
+
+		& .text-bga-gray-78,
+		& .text-base {
+			color: var(--gametile-color);
+		}
+
+		& .bga-table-list-item__details {
+			& .bga-table-list-item__status-mode-icon {
+				color: var(--gametile-icon-color);
+			}
+		}
+	}
+
+	& > div.bga-table-list-item__players-list.flex {
+		background-color: var(--gametile-surface-color);
+		border: 1px solid var(--gametile-border-color);
+	}
+}
+
+/* .bga-table-list-item {
+	&:has(> .bga-table-list-item__background[style$="rgb(64, 117, 158);"]) {
+		--surface-color: var(--play-gametile-surface-color);
+		--color: var(--play-gametile-color);
+	}
+
+	& .bga-table-list-item__main {
+		background-color: var(--surface-color);
+
+		& .text-bga-gray-78,
+		& .text-base {
+			color: var(--color);
+		}
+	}
+
+	& .bga-table-list-item__players-list {
+		background-color: var(--surface-color);
+	}
+
+	& div.bga-table-list-item__status-mode-icon,
+	& .text-bga-link {
+		color: var(--color);
+	}
+
+	& .bga-table-list-item__status-mode-icon-inverse-border {
+		box-shadow: unset;
+	}
+} */

--- a/src/css/colorfulTables.css
+++ b/src/css/colorfulTables.css
@@ -1,0 +1,3 @@
+body {
+	background: #ff0000 !important;
+}

--- a/src/css/colorfulTables.css
+++ b/src/css/colorfulTables.css
@@ -55,7 +55,12 @@ html {
 
 		& .bga-table-list-item__details {
 			& .bga-table-list-item__status-mode-icon {
+				background-color: unset;
 				color: var(--gametile-icon-color);
+			}
+
+			& .bga-table-list-item__status-mode-icon-inverse-border {
+				box-shadow: unset;
 			}
 		}
 	}
@@ -65,32 +70,3 @@ html {
 		border: 1px solid var(--gametile-border-color);
 	}
 }
-
-/* .bga-table-list-item {
-	&:has(> .bga-table-list-item__background[style$="rgb(64, 117, 158);"]) {
-		--surface-color: var(--play-gametile-surface-color);
-		--color: var(--play-gametile-color);
-	}
-
-	& .bga-table-list-item__main {
-		background-color: var(--surface-color);
-
-		& .text-bga-gray-78,
-		& .text-base {
-			color: var(--color);
-		}
-	}
-
-	& .bga-table-list-item__players-list {
-		background-color: var(--surface-color);
-	}
-
-	& div.bga-table-list-item__status-mode-icon,
-	& .text-bga-link {
-		color: var(--color);
-	}
-
-	& .bga-table-list-item__status-mode-icon-inverse-border {
-		box-shadow: unset;
-	}
-} */

--- a/src/js/config/configuration.ts
+++ b/src/js/config/configuration.ts
@@ -955,7 +955,7 @@ class Configuration {
 		return cssList.join("\n");
 	}
 
-	isInProgressColorfulTables(): boolean {
+	useInProgressColorfulTables(): boolean {
 		return this._customConfig.inProgress?.colorfulTables === true;
 	}
 }

--- a/src/js/config/configuration.ts
+++ b/src/js/config/configuration.ts
@@ -1,6 +1,12 @@
 import equal from "fast-deep-equal";
 import defaultGames from "./sideMenuGames";
-import { addChangeListener, localStorageGet, localStorageSet, storageGet, storageSet } from "../utils/chrome";
+import {
+	addChangeListener,
+	localStorageGet,
+	localStorageSet,
+	storageGet,
+	storageSet,
+} from "../utils/chrome";
 
 const DEF_HOME_HTML = `<style>
 #bgaext-newsfeed .bga-homepage-newsfeed {
@@ -95,7 +101,7 @@ interface CustomConfig {
 	lobbyRedirect?: boolean;
 	autoOpen?: boolean;
 	solidBack?: boolean;
-};
+}
 
 export interface HomeConfig {
 	header: boolean;
@@ -112,24 +118,25 @@ export interface HomeConfig {
 	recommandedGames: boolean;
 	classicGames: boolean;
 	events: boolean;
-};
+}
 
 export interface AdvancedHomeConfig {
 	advanced: boolean;
 	html: string;
-};
+}
 
 export interface InProgressConfig {
 	emptySections: boolean;
 	playAgain: boolean;
 	discover: boolean;
 	more: boolean;
-};
+	colorfulTables: boolean;
+}
 
 interface LocalConfig {
 	css: string;
 	home?: AdvancedHomeConfig;
-};
+}
 
 class Configuration {
 	_defConfig: { games: Game[] };
@@ -168,13 +175,16 @@ class Configuration {
 			disabled: [],
 			floating: [],
 			hidden: [],
-			muted: []
+			muted: [],
 		};
 		this._config = { games: [] };
 	}
 
 	async init() {
-		const [syncStorage, localStorage] = await Promise.all([storageGet(), localStorageGet()]);
+		const [syncStorage, localStorage] = await Promise.all([
+			storageGet(),
+			localStorageGet(),
+		]);
 
 		this._customConfig = syncStorage;
 		this._localConfig = localStorage;
@@ -207,15 +217,21 @@ class Configuration {
 
 		addChangeListener((changes: any, namespace: string) => {
 			try {
-				for (let [key, { newValue }] of Object.entries(changes) as any) {
+				for (let [key, { newValue }] of Object.entries(
+					changes,
+				) as any) {
 					if (namespace === "local") {
 						this._localConfig[key] = newValue;
 					} else {
 						this._customConfig[key] = newValue;
 					}
-					document.dispatchEvent(new CustomEvent('bga_ext_update_config', { detail: { key } }));
+					document.dispatchEvent(
+						new CustomEvent("bga_ext_update_config", {
+							detail: { key },
+						}),
+					);
 				}
-			} catch (error) { } // not a big deal
+			} catch (error) {} // not a big deal
 		});
 	}
 
@@ -332,13 +348,17 @@ class Configuration {
 	}
 
 	getHomeConfig() {
-		const homeConfig = this._customConfig.home || {} as any;
+		const homeConfig = this._customConfig.home || ({} as any);
 
 		return {
 			header: true,
 			footer: true,
 			latestNews: true,
-			howToPlay: homeConfig?.howToPlay === undefined && homeConfig?.latestNews !== undefined ? homeConfig.latestNews : true,
+			howToPlay:
+				homeConfig?.howToPlay === undefined &&
+				homeConfig?.latestNews !== undefined
+					? homeConfig.latestNews
+					: true,
 			smallFeed: true,
 			fewFeeds: true,
 			status: true,
@@ -349,7 +369,7 @@ class Configuration {
 			recommandedGames: true,
 			classicGames: true,
 			events: true,
-			...homeConfig
+			...homeConfig,
 		};
 	}
 
@@ -359,12 +379,12 @@ class Configuration {
 	}
 
 	getAdvancedHomeConfig() {
-		const homeConfig = this._localConfig.home || {} as any;
+		const homeConfig = this._localConfig.home || ({} as any);
 
 		return {
 			advanced: false,
 			html: DEF_HOME_HTML,
-			...homeConfig
+			...homeConfig,
 		};
 	}
 
@@ -379,8 +399,8 @@ class Configuration {
 			playAgain: true,
 			discover: true,
 			more: true,
-			...(this._customConfig.inProgress || {})
-		}
+			...(this._customConfig.inProgress || {}),
+		};
 	}
 
 	setInProgressConfig(val: InProgressConfig) {
@@ -552,7 +572,10 @@ class Configuration {
 	}
 
 	isMuteWarning() {
-		return this._customConfig.muteWarning === undefined || this._customConfig.muteWarning === true;
+		return (
+			this._customConfig.muteWarning === undefined ||
+			this._customConfig.muteWarning === true
+		);
 	}
 
 	hideGame(name: string) {
@@ -617,9 +640,9 @@ class Configuration {
 
 	getChatStyle() {
 		if (this._customConfig.hideGeneralChat) {
-			return '#bga_extension_chat_icon { color: #c4c4c4; } #chatwindow_general { display: none !important; }';
+			return "#bga_extension_chat_icon { color: #c4c4c4; } #chatwindow_general { display: none !important; }";
 		}
-		return '#bga_extension_chat_icon { color: #01c4ca; } #chatwindow_general { display: inline-block !important; }';
+		return "#bga_extension_chat_icon { color: #01c4ca; } #chatwindow_general { display: inline-block !important; }";
 	}
 
 	isEloHidden() {
@@ -633,9 +656,9 @@ class Configuration {
 
 	getEloStyle() {
 		if (this._customConfig.hideElo) {
-			return '.player_elo_wrap, #game_result .adddetails, #table_stats .row-data:has(> .row-value > .gamerank) { display: none; } '
+			return ".player_elo_wrap, #game_result .adddetails, #table_stats .row-data:has(> .row-value > .gamerank) { display: none; } ";
 		}
-		return '';
+		return "";
 	}
 
 	isDarkMode() {
@@ -648,13 +671,18 @@ class Configuration {
 	}
 
 	getDarkModeColor(gameName: string, def: number) {
-		const mainValue = this._customConfig.darkModeColor === undefined ? -1 : this._customConfig.darkModeColor;
+		const mainValue =
+			this._customConfig.darkModeColor === undefined
+				? -1
+				: this._customConfig.darkModeColor;
 
 		if (gameName === "general" || gameName === "forum") {
 			return mainValue;
 		}
 
-		const result = this._customConfig.dark.find(d => d.name === gameName)?.color;
+		const result = this._customConfig.dark.find(
+			(d) => d.name === gameName,
+		)?.color;
 		return result === undefined ? def || mainValue : result;
 	}
 
@@ -664,22 +692,39 @@ class Configuration {
 			return mainValue;
 		}
 
-		return this._customConfig.dark.find(d => d.name === gameName)?.sat || def || mainValue;
+		return (
+			this._customConfig.dark.find((d) => d.name === gameName)?.sat ||
+			def ||
+			mainValue
+		);
 	}
 
-	setDarkModeColor(gameName: string, darkModeColor: number, darkModeSat: number, forceSave?: boolean) {
+	setDarkModeColor(
+		gameName: string,
+		darkModeColor: number,
+		darkModeSat: number,
+		forceSave?: boolean,
+	) {
 		if (gameName === "general" || gameName === "forum") {
 			this._customConfig.darkModeColor = darkModeColor;
 			this._customConfig.darkModeSat = darkModeSat;
 			storageSet({ darkModeColor, darkModeSat });
 		} else {
-			if (!forceSave && this._customConfig.darkModeColor === darkModeColor && this._customConfig.darkModeSat === darkModeSat) {
+			if (
+				!forceSave &&
+				this._customConfig.darkModeColor === darkModeColor &&
+				this._customConfig.darkModeSat === darkModeSat
+			) {
 				// default config
-				this._customConfig.dark = this._customConfig.dark.filter(d => d.name !== gameName);
+				this._customConfig.dark = this._customConfig.dark.filter(
+					(d) => d.name !== gameName,
+				);
 			} else {
 				this._customConfig.dark = [
-					...this._customConfig.dark.filter(d => d.name !== gameName),
-					{ name: gameName, color: darkModeColor, sat: darkModeSat }
+					...this._customConfig.dark.filter(
+						(d) => d.name !== gameName,
+					),
+					{ name: gameName, color: darkModeColor, sat: darkModeSat },
 				];
 			}
 
@@ -688,7 +733,9 @@ class Configuration {
 	}
 
 	clearDarkModeColor(gameName: string) {
-		this._customConfig.dark = this._customConfig.dark.filter(d => d.name !== gameName);
+		this._customConfig.dark = this._customConfig.dark.filter(
+			(d) => d.name !== gameName,
+		);
 		storageSet({ dark: this._customConfig.dark });
 	}
 
@@ -712,20 +759,32 @@ class Configuration {
 		const cssList: string[] = [];
 
 		if (advHome.advanced) {
-			cssList.push(`.bgaext_welcome .post.bga-hover-for-list { display: block !important; }`);
-			cssList.push('.bgaext_welcome .bga-homepage-header { display: none; }');
-			cssList.push(`#bgadef-homepage { height: 1px; zoom: 0.1; opacity: 0 }`);
-			cssList.push('#bgaext-tournaments { width: 100%; }');
-			cssList.push('#bgaext-homepage { padding: 2em; }');
-			cssList.push('.bgaext-flex-row { display: flex; flex-flow: row nowrap; gap: 2em; justify-content: space-between; }');
-			cssList.push('.bgaext-flex-row > div { flex-grow: 1; }');
-			cssList.push('.bgaext-flex-col { display: flex; flex-flow: column; gap: 1em; }');
-			cssList.push('#bgaext-homepage .bga-generic-game-item:hover .bga-hover-animated-border:before { -webkit-clip-path: circle(142% at bottom left); clip-path: circle(142% at bottom left); }');
+			cssList.push(
+				`.bgaext_welcome .post.bga-hover-for-list { display: block !important; }`,
+			);
+			cssList.push(
+				".bgaext_welcome .bga-homepage-header { display: none; }",
+			);
+			cssList.push(
+				`#bgadef-homepage { height: 1px; zoom: 0.1; opacity: 0 }`,
+			);
+			cssList.push("#bgaext-tournaments { width: 100%; }");
+			cssList.push("#bgaext-homepage { padding: 2em; }");
+			cssList.push(
+				".bgaext-flex-row { display: flex; flex-flow: row nowrap; gap: 2em; justify-content: space-between; }",
+			);
+			cssList.push(".bgaext-flex-row > div { flex-grow: 1; }");
+			cssList.push(
+				".bgaext-flex-col { display: flex; flex-flow: column; gap: 1em; }",
+			);
+			cssList.push(
+				"#bgaext-homepage .bga-generic-game-item:hover .bga-hover-animated-border:before { -webkit-clip-path: circle(142% at bottom left); clip-path: circle(142% at bottom left); }",
+			);
 		} else {
 			let columns = 3;
 
 			// If we want to display events, display the recent games section
-			if (home.events && document.querySelector('.bga-advent-calendar')) {
+			if (home.events && document.querySelector(".bga-advent-calendar")) {
 				home.recentGames = true;
 			}
 
@@ -733,102 +792,171 @@ class Configuration {
 				cssList.push(this._localConfig.css);
 			}
 			if (!home.header) {
-				cssList.push('.bgaext_welcome .bga-homepage-header { display: none; }');
+				cssList.push(
+					".bgaext_welcome .bga-homepage-header { display: none; }",
+				);
 			}
 			if (!home.footer) {
-				cssList.push('.bgaext_welcome .bga-homepage__pre-footer { visibility: hidden; height: 1px; }');
+				cssList.push(
+					".bgaext_welcome .bga-homepage__pre-footer { visibility: hidden; height: 1px; }",
+				);
 			}
 			if (!home.latestNews) {
-				cssList.push('.bgaext_welcome div:has(>.bga-homepage__out-grid-title):has([href="/headlines"]) { display: none; }');
+				cssList.push(
+					'.bgaext_welcome div:has(>.bga-homepage__out-grid-title):has([href="/headlines"]) { display: none; }',
+				);
 			}
 			if (!home.howToPlay) {
-				cssList.push('.bgaext_welcome div:has(>.bga-homepage__out-grid-title):has([href="/gamelist?hasTutorialOnly"]) { display: none; }');
+				cssList.push(
+					'.bgaext_welcome div:has(>.bga-homepage__out-grid-title):has([href="/gamelist?hasTutorialOnly"]) { display: none; }',
+				);
 			}
 
-			if (!home.recentGames && !home.popularGames && !home.recommandedGames && !home.classicGames) {
-				cssList.push('.bgaext_welcome .bga-homepage__content { display: flex; }');
-				cssList.push('.bgaext_welcome .bga-homepage__games-section { display: none; }');
+			if (
+				!home.recentGames &&
+				!home.popularGames &&
+				!home.recommandedGames &&
+				!home.classicGames
+			) {
+				cssList.push(
+					".bgaext_welcome .bga-homepage__content { display: flex; }",
+				);
+				cssList.push(
+					".bgaext_welcome .bga-homepage__games-section { display: none; }",
+				);
 				columns = 0;
 			} else {
 				if (!home.recentGames) {
-					cssList.push('.bgaext_welcome .flex-1:has(>.homepage-section>.homepage-section__title>[href*="/gamelist?isRecent"]) { display: none; }');
+					cssList.push(
+						'.bgaext_welcome .flex-1:has(>.homepage-section>.homepage-section__title>[href*="/gamelist?isRecent"]) { display: none; }',
+					);
 					--columns;
 				}
 				if (!home.popularGames) {
-					cssList.push('.bgaext_welcome .flex-1:has(>.homepage-section>.homepage-section__title>[href*="/gamelist?isPopular"]) { display: none; }');
+					cssList.push(
+						'.bgaext_welcome .flex-1:has(>.homepage-section>.homepage-section__title>[href*="/gamelist?isPopular"]) { display: none; }',
+					);
 					--columns;
 				}
 				if (!home.recommandedGames) {
-					cssList.push('.bgaext_welcome .flex-1:has(>.homepage-section>.homepage-section__title>[href*="/gamelist?isSuggested"]) { display: none; }');
+					cssList.push(
+						'.bgaext_welcome .flex-1:has(>.homepage-section>.homepage-section__title>[href*="/gamelist?isSuggested"]) { display: none; }',
+					);
 					--columns;
 				}
 				if (!home.classicGames) {
-					cssList.push('.bgaext_welcome .bga-homepage__games-section > div:last-child { display: none; }')
+					cssList.push(
+						".bgaext_welcome .bga-homepage__games-section > div:last-child { display: none; }",
+					);
 				} else if (columns === 0) {
 					columns = 1;
 				}
 			}
 			if (!home.tournamentsBelow && home.tournaments) {
-				cssList.push('.bgaext_welcome div:has(>.bga-homepage__newsfeed) { flex-flow: row; }');
-				cssList.push('.bgaext_welcome div:has(>.bga-homepage__newsfeed) > div:last-child { flex-grow: 1; min-width: 450px; }');
+				cssList.push(
+					".bgaext_welcome div:has(>.bga-homepage__newsfeed) { flex-flow: row; }",
+				);
+				cssList.push(
+					".bgaext_welcome div:has(>.bga-homepage__newsfeed) > div:last-child { flex-grow: 1; min-width: 450px; }",
+				);
 
-				cssList.push('.bgaext_welcome .bga-homepage__newsfeed { flex-shrink: 10; }');
-				cssList.push('.bgaext_welcome .bga-homepage__content { gap: 2em !important; }');
+				cssList.push(
+					".bgaext_welcome .bga-homepage__newsfeed { flex-shrink: 10; }",
+				);
+				cssList.push(
+					".bgaext_welcome .bga-homepage__content { gap: 2em !important; }",
+				);
 
 				if (columns === 0) {
-					cssList.push('.bgaext_welcome .bga-homepage__content { flex-flow: column; }');
+					cssList.push(
+						".bgaext_welcome .bga-homepage__content { flex-flow: column; }",
+					);
 				}
 			}
 
 			if (columns === 0 && (home.tournamentsBelow || !home.tournaments)) {
-				cssList.push('.bgaext_welcome .bga-homepage__newsfeed { width: 100%; }');
+				cssList.push(
+					".bgaext_welcome .bga-homepage__newsfeed { width: 100%; }",
+				);
 			}
 
 			if (!home.smallFeed) {
-				cssList.push(`.bgaext_welcome .desktop_version .bga-homepage__content { grid-template-columns: minmax(0, ${300 * columns}px) minmax(0, 100%) !important; }`);
+				cssList.push(
+					`.bgaext_welcome .desktop_version .bga-homepage__content { grid-template-columns: minmax(0, ${300 * columns}px) minmax(0, 100%) !important; }`,
+				);
 			} else if (!home.tournamentsBelow) {
-				cssList.push(`.bgaext_welcome .bga-homepage__content { grid-template-columns: minmax(0, 40%) minmax(0, 60%) !important; }`);
+				cssList.push(
+					`.bgaext_welcome .bga-homepage__content { grid-template-columns: minmax(0, 40%) minmax(0, 60%) !important; }`,
+				);
 			}
 
 			if (!home.fewFeeds || !home.tournaments || !home.tournamentsBelow) {
-				cssList.push(`.bgaext_welcome .post.bga-hover-for-list { display: block !important; }`);
+				cssList.push(
+					`.bgaext_welcome .post.bga-hover-for-list { display: block !important; }`,
+				);
 			}
 
 			if (!home.smallFeed || !home.tournamentsBelow) {
-				cssList.push('.bgaext_welcome .bga-homepage__partner-events-section { display: none; }');
+				cssList.push(
+					".bgaext_welcome .bga-homepage__partner-events-section { display: none; }",
+				);
 			}
 
 			if (!home.status) {
-				cssList.push(`.bgaext_welcome .bga-homepage__service-status-section { display: none; }`);
+				cssList.push(
+					`.bgaext_welcome .bga-homepage__service-status-section { display: none; }`,
+				);
 			}
 			if (!home.tournaments) {
-				cssList.push('.bgaext_welcome div:has(>.homepage-section>.homepage-section__title>[href="/tournamentlist"]) { display: none; }');
-				cssList.push('.bgaext_welcome div:has(>.bga-homepage__newsfeed-controls-wrapper) { display: none; }');
+				cssList.push(
+					'.bgaext_welcome div:has(>.homepage-section>.homepage-section__title>[href="/tournamentlist"]) { display: none; }',
+				);
+				cssList.push(
+					".bgaext_welcome div:has(>.bga-homepage__newsfeed-controls-wrapper) { display: none; }",
+				);
 			}
 			if (columns < 3) {
-				cssList.push(`.bgaext_welcome .bga-homepage__games-section .grid-cols-3 { grid-template-columns: repeat(${columns}, minmax(0, 1fr)); }`);
+				cssList.push(
+					`.bgaext_welcome .bga-homepage__games-section .grid-cols-3 { grid-template-columns: repeat(${columns}, minmax(0, 1fr)); }`,
+				);
 
 				if (columns === 1) {
-					cssList.push('.bgaext_welcome .bga-homepage__discover-section { grid-template-columns: repeat(1, minmax(0, 1fr)) !important; }');
-					cssList.push('.bgaext_welcome .bga-homepage__discover-section>div:last-child { display: none; }');
+					cssList.push(
+						".bgaext_welcome .bga-homepage__discover-section { grid-template-columns: repeat(1, minmax(0, 1fr)) !important; }",
+					);
+					cssList.push(
+						".bgaext_welcome .bga-homepage__discover-section>div:last-child { display: none; }",
+					);
 				}
 			}
 		}
 
 		if (!inProgress.emptySections) {
-			cssList.push('.bgaext_gameinprogress .bga-player-progress-list__section:has(>div.relative>div.relative>div.relative>div.flex.items-center) { display: none; }');
+			cssList.push(
+				".bgaext_gameinprogress .bga-player-progress-list__section:has(>div.relative>div.relative>div.relative>div.flex.items-center) { display: none; }",
+			);
 		}
 		if (!inProgress.playAgain) {
-			cssList.push('.bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(1), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(2), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(3) { display: none; }');
+			cssList.push(
+				".bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(1), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(2), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(3) { display: none; }",
+			);
 		}
 		if (!inProgress.discover) {
-			cssList.push('.bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(4), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(5), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(6) { display: none; }');
+			cssList.push(
+				".bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(4), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(5), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(6) { display: none; }",
+			);
 		}
 		if (!inProgress.more) {
-			cssList.push('.bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(7), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(8), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(9) { display: none; }');
+			cssList.push(
+				".bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(7), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(8), .bgaext_gameinprogress #main-content > div:first-child > div:last-child > div:nth-child(9) { display: none; }",
+			);
 		}
 
-		return cssList.join('\n');
+		return cssList.join("\n");
+	}
+
+	isInProgressColorfulTables(): boolean {
+		return this._customConfig.inProgress?.colorfulTables === true;
 	}
 }
 

--- a/src/js/ui/content/functions.js
+++ b/src/js/ui/content/functions.js
@@ -654,17 +654,25 @@ const setEloStyle = (config) => {
 };
 
 const setInProgressTableStyle = (config) => {
-	if (config.isInProgressColorfulTables()) {
-		const css = document.getElementById("bgaext-colorfultables-style");
-		if (!css) {
-			const link = document.createElement("link");
-			link.id = "bgaext-colorfultables-style";
-			link.rel = "stylesheet";
-			link.href = `${chrome.runtime.getURL(
-				"/css/colorfulTables.css",
-			)}?&time=${new Date().getTime()}`;
-			document.head.appendChild(link);
+	const useColorfulTables = config.useInProgressColorfulTables();
+	const css = document.getElementById("bgaext-colorfultables-style");
+
+	if (useColorfulTables === false) {
+		if (css !== null) {
+			css.remove();
 		}
+
+		return;
+	}
+
+	if (css === null) {
+		const link = document.createElement("link");
+		link.id = "bgaext-colorfultables-style";
+		link.rel = "stylesheet";
+		link.href = `${chrome.runtime.getURL(
+			"/css/colorfulTables.css",
+		)}?&time=${new Date().getTime()}`;
+		document.head.appendChild(link);
 	}
 };
 

--- a/src/js/ui/content/functions.js
+++ b/src/js/ui/content/functions.js
@@ -3,23 +3,23 @@ import {
 	initLeftMenu,
 	buildLeftMenu,
 	buildLeftMenuCss,
-} from './leftMenu/functions';
-import { setFloatingRightMenu } from './rightMenu/functions';
-import { initDevelopperUI } from './studio/functions';
-import { initGameListObserver } from './gameList/functions';
-import { initDarkMode } from './darkMode/functions';
-import ConfirmationPopup from './misc/ConfirmationPopup';
-import InformationPopup from './misc/InformationPopup';
-import { waitForObj } from '../../utils/misc/wait';
-import shouldFilter from '../../config/filteredLogs';
+} from "./leftMenu/functions";
+import { setFloatingRightMenu } from "./rightMenu/functions";
+import { initDevelopperUI } from "./studio/functions";
+import { initGameListObserver } from "./gameList/functions";
+import { initDarkMode } from "./darkMode/functions";
+import ConfirmationPopup from "./misc/ConfirmationPopup";
+import InformationPopup from "./misc/InformationPopup";
+import { waitForObj } from "../../utils/misc/wait";
+import shouldFilter from "../../config/filteredLogs";
 
 const buildMainCss = (code) => {
-	waitForObj('head', 10).then(() => {
-		let style = document.getElementById('cde_bga_ext');
+	waitForObj("head", 10).then(() => {
+		let style = document.getElementById("cde_bga_ext");
 
 		if (!style) {
-			style = document.createElement('style');
-			style.id = 'cde_bga_ext';
+			style = document.createElement("style");
+			style.id = "cde_bga_ext";
 			document.head.appendChild(style);
 		}
 		style.innerHTML = `
@@ -55,22 +55,35 @@ const mutePlayer = (config, evt) => {
 			const msg = `${playerName} has been muted, I will no longer receive their messages. \n[Feature provided by: https://en.doc.boardgamearena.com/ChromeExtension]`;
 			const endPoint = `/table/table/say.html`;
 			const key = new Date().getTime();
-			const body = new URLSearchParams({ table: tableId, msg, noerrortracking: true, "dojo.preventCache": key }).toString();
-			const detail = JSON.stringify({ method: 'POST', endPoint, key, body, type: 'say' });
-			document.body.dispatchEvent(new CustomEvent('bga_ext_api_call', { detail }));
+			const body = new URLSearchParams({
+				table: tableId,
+				msg,
+				noerrortracking: true,
+				"dojo.preventCache": key,
+			}).toString();
+			const detail = JSON.stringify({
+				method: "POST",
+				endPoint,
+				key,
+				body,
+				type: "say",
+			});
+			document.body.dispatchEvent(
+				new CustomEvent("bga_ext_api_call", { detail }),
+			);
 		}
 	};
 
 	if (localStorage.getItem("ext_mute_warning") === "off") {
 		doMute();
 	} else {
-		const container = document.createElement('div');
+		const container = document.createElement("div");
 		container.id = "bgaext_popup_container";
 		document.body.appendChild(container);
 
 		const close = () => {
 			container.remove();
-		}
+		};
 		const confirm = (stopWarn) => {
 			if (stopWarn) {
 				localStorage.setItem("ext_mute_warning", "off");
@@ -79,7 +92,15 @@ const mutePlayer = (config, evt) => {
 			close();
 		};
 
-		render(<ConfirmationPopup type='mute_player' confirm={confirm} cancel={close} config={config} />, container);
+		render(
+			<ConfirmationPopup
+				type="mute_player"
+				confirm={confirm}
+				cancel={close}
+				config={config}
+			/>,
+			container,
+		);
 	}
 };
 
@@ -91,7 +112,7 @@ const displayInformationPopup = () => {
 	}
 
 	const now = new Date().getTime();
-	const showDate = parseInt(extInfosDialog || '0', 10);
+	const showDate = parseInt(extInfosDialog || "0", 10);
 
 	if (showDate > now) {
 		//console.log("pas maintenant " + new Date(showDate));
@@ -100,36 +121,72 @@ const displayInformationPopup = () => {
 
 	localStorage.setItem("ext_infos_dialog", now + 8 * 60 * 60 * 1000);
 
-	const container = document.createElement('div');
+	const container = document.createElement("div");
 	container.id = "bgaext_popup_container";
 	document.body.appendChild(container);
 
 	const close = () => {
 		localStorage.setItem("ext_infos_dialog", "off");
 		container.remove();
-	}
+	};
 	const later = () => {
 		container.remove();
 	};
 
-	const isFirefox = window.navigator.userAgent.toLowerCase().includes('firefox');
-	const title = isFirefox ? chrome.i18n.getMessage("infosTitleFirefox") : chrome.i18n.getMessage("infosTitleChrome");
+	const isFirefox = window.navigator.userAgent
+		.toLowerCase()
+		.includes("firefox");
+	const title = isFirefox
+		? chrome.i18n.getMessage("infosTitleFirefox")
+		: chrome.i18n.getMessage("infosTitleChrome");
 	const content = (
 		<div>
-			<p>{isFirefox ? chrome.i18n.getMessage("infosSubTitleFirefox") : chrome.i18n.getMessage("infosSubTitleChrome")}</p>
-			<p dangerouslySetInnerHTML={{ __html: chrome.i18n.getMessage("infosLine1") }}></p>
-			<p dangerouslySetInnerHTML={{ __html: chrome.i18n.getMessage("infosLine2") }}></p>
-			<p dangerouslySetInnerHTML={{ __html: chrome.i18n.getMessage("infosLine3") }}></p>
-			<p dangerouslySetInnerHTML={{ __html: chrome.i18n.getMessage("infosLine4") }}></p>
-			<p dangerouslySetInnerHTML={{ __html: chrome.i18n.getMessage("infosLine5") }}></p>
+			<p>
+				{isFirefox
+					? chrome.i18n.getMessage("infosSubTitleFirefox")
+					: chrome.i18n.getMessage("infosSubTitleChrome")}
+			</p>
+			<p
+				dangerouslySetInnerHTML={{
+					__html: chrome.i18n.getMessage("infosLine1"),
+				}}
+			></p>
+			<p
+				dangerouslySetInnerHTML={{
+					__html: chrome.i18n.getMessage("infosLine2"),
+				}}
+			></p>
+			<p
+				dangerouslySetInnerHTML={{
+					__html: chrome.i18n.getMessage("infosLine3"),
+				}}
+			></p>
+			<p
+				dangerouslySetInnerHTML={{
+					__html: chrome.i18n.getMessage("infosLine4"),
+				}}
+			></p>
+			<p
+				dangerouslySetInnerHTML={{
+					__html: chrome.i18n.getMessage("infosLine5"),
+				}}
+			></p>
 		</div>
 	);
 
-	render(<InformationPopup title={title} content={content} later={later} close={close} />, container);
+	render(
+		<InformationPopup
+			title={title}
+			content={content}
+			later={later}
+			close={close}
+		/>,
+		container,
+	);
 };
 
 const refreshMutedPlayers = (config) => {
-	const chatContainer = document.querySelector('#chatbar');
+	const chatContainer = document.querySelector("#chatbar");
 
 	mutedPlayers = config.getMutedPlayers();
 	if (chatContainer) {
@@ -138,20 +195,20 @@ const refreshMutedPlayers = (config) => {
 };
 
 const hideElement = (elt) => {
-	if (!elt.classList.contains('bgaext_chat_hidden')) {
-		elt.classList.add('bgaext_chat_hidden');
+	if (!elt.classList.contains("bgaext_chat_hidden")) {
+		elt.classList.add("bgaext_chat_hidden");
 	}
-	if (elt.classList.contains('bgaext_chat_visible')) {
-		elt.classList.remove('bgaext_chat_visible');
+	if (elt.classList.contains("bgaext_chat_visible")) {
+		elt.classList.remove("bgaext_chat_visible");
 	}
 };
 
 const displayElement = (elt, force) => {
-	if (elt.classList.contains('bgaext_chat_hidden')) {
-		elt.classList.remove('bgaext_chat_hidden');
+	if (elt.classList.contains("bgaext_chat_hidden")) {
+		elt.classList.remove("bgaext_chat_hidden");
 	}
-	if (force && !elt.classList.contains('bgaext_chat_visible')) {
-		elt.classList.add('bgaext_chat_visible');
+	if (force && !elt.classList.contains("bgaext_chat_visible")) {
+		elt.classList.add("bgaext_chat_visible");
 	}
 };
 
@@ -160,7 +217,11 @@ const hideMutedPlayerWriting = (writingSpanId, writingAreaId, titleAreaId) => {
 	const writingArea = document.getElementById(writingAreaId);
 	const titleArea = document.getElementById(titleAreaId);
 
-	if (writingArea.style.display === 'none' || !writingSpan.innerHTML || mutedPlayers.find(name => writingSpan.innerHTML.indexOf(name) >= 0)) {
+	if (
+		writingArea.style.display === "none" ||
+		!writingSpan.innerHTML ||
+		mutedPlayers.find((name) => writingSpan.innerHTML.indexOf(name) >= 0)
+	) {
 		hideElement(writingArea);
 		displayElement(titleArea, true);
 	} else {
@@ -173,12 +234,15 @@ const getMessageText = (container, name) => {
 	if (container.nodeName === "#text" && container.nodeValue !== name) {
 		return container.nodeValue;
 	}
-	return Array.from(container.childNodes || []).map((node) => getMessageText(node, name)).find(v => Boolean(v))?.trim();
+	return Array.from(container.childNodes || [])
+		.map((node) => getMessageText(node, name))
+		.find((v) => Boolean(v))
+		?.trim();
 };
 
 const muteChatMessage = (config, tableId, msg) => {
 	try {
-		const span = msg.querySelector('.playername');
+		const span = msg.querySelector(".playername");
 		const name = span.innerHTML.trim();
 
 		if (mutedPlayers.includes(name)) {
@@ -186,34 +250,44 @@ const muteChatMessage = (config, tableId, msg) => {
 		} else {
 			displayElement(msg);
 
-			lastMessage[tableId] = { user: span.innerHTML.trim(), color: span.style.color, text: getMessageText(msg, name) };
+			lastMessage[tableId] = {
+				user: span.innerHTML.trim(),
+				color: span.style.color,
+				text: getMessageText(msg, name),
+			};
 
-			const trIcon = msg.querySelector('.translate_icon');
+			const trIcon = msg.querySelector(".translate_icon");
 			if (trIcon) {
-				const muteIconId = trIcon.id.replace('logtr_table', 'mute_icon');
+				const muteIconId = trIcon.id.replace(
+					"logtr_table",
+					"mute_icon",
+				);
 
 				if (!document.getElementById(muteIconId)) {
-					const muteIcon = document.createElement('div');
+					const muteIcon = document.createElement("div");
 					muteIcon.dataset.player = name;
 					muteIcon.dataset.table = tableId;
 					muteIcon.id = muteIconId;
-					muteIcon.className = 'bgaext_chat_mute_icon';
-					muteIcon.innerHTML = '<i class="fa fa-microphone-slash"></i>';
+					muteIcon.className = "bgaext_chat_mute_icon";
+					muteIcon.innerHTML =
+						'<i class="fa fa-microphone-slash"></i>';
 					muteIcon.onclick = (evt) => mutePlayer(config, evt);
 					trIcon.parentNode.appendChild(muteIcon);
 				}
 			}
 		}
-	}
-	catch (error) {
-		console.warn("[bga extension] Can't process chat message", { message: msg.outerHTML, error });
+	} catch (error) {
+		console.warn("[bga extension] Can't process chat message", {
+			message: msg.outerHTML,
+			error,
+		});
 	}
 };
 
 const playPlop = () => {
-	const extAudioTag = document.getElementById('ext_audiosrc_o_alt_Plop');
-	const volumeTag = document.getElementById('soundVolumeControl');
-	const volumeValue = volumeTag ? parseFloat(volumeTag.value) / 100 : 0.5
+	const extAudioTag = document.getElementById("ext_audiosrc_o_alt_Plop");
+	const volumeTag = document.getElementById("soundVolumeControl");
+	const volumeValue = volumeTag ? parseFloat(volumeTag.value) / 100 : 0.5;
 
 	if (extAudioTag) {
 		extAudioTag.volume = volumeValue;
@@ -223,18 +297,36 @@ const playPlop = () => {
 
 const muteChatTable = (config, chatTable) => {
 	try {
-		const id = chatTable.id.split('_').pop();
-		const messages = Array.from(chatTable.querySelectorAll('.chatlog'));
+		const id = chatTable.id.split("_").pop();
+		const messages = Array.from(chatTable.querySelectorAll(".chatlog"));
 
-		const prevLastMessage = lastMessage[id] || { user: '', color: '', text: '' };
-		messages.forEach(msg => muteChatMessage(config, id, msg));
-		const newLastMessage = lastMessage[id] || { user: '', color: '', text: '' };
+		const prevLastMessage = lastMessage[id] || {
+			user: "",
+			color: "",
+			text: "",
+		};
+		messages.forEach((msg) => muteChatMessage(config, id, msg));
+		const newLastMessage = lastMessage[id] || {
+			user: "",
+			color: "",
+			text: "",
+		};
 
-		hideMutedPlayerWriting(`is_writing_now_expl_title_table_${id}`, `is_writing_now_title_table_${id}`, `chatwindowlogstitle_content_table_${id}`);
-		hideMutedPlayerWriting(`is_writing_now_expl_table_${id}`, `is_writing_now_table_${id}`, `chatwindowtitlenolink_table_${id}`);
+		hideMutedPlayerWriting(
+			`is_writing_now_expl_title_table_${id}`,
+			`is_writing_now_title_table_${id}`,
+			`chatwindowlogstitle_content_table_${id}`,
+		);
+		hideMutedPlayerWriting(
+			`is_writing_now_expl_table_${id}`,
+			`is_writing_now_table_${id}`,
+			`chatwindowtitlenolink_table_${id}`,
+		);
 
-		const previewArea = document.getElementById(`chatwindowtitlenolink_table_${id}`);
-		const previewPlayerSpan = previewArea.querySelector('.playername');
+		const previewArea = document.getElementById(
+			`chatwindowtitlenolink_table_${id}`,
+		);
+		const previewPlayerSpan = previewArea.querySelector(".playername");
 
 		if (previewPlayerSpan) {
 			if (lastMessage[id]) {
@@ -244,34 +336,48 @@ const muteChatTable = (config, chatTable) => {
 					previewPlayerSpan.nextSibling.nodeValue = ` ${lastMessage[id].text}`;
 				}
 			} else {
-				previewArea.innerHTML = document.getElementById(`chatwindowlogstitle_content_table_${id}`).innerHTML;
+				previewArea.innerHTML = document.getElementById(
+					`chatwindowlogstitle_content_table_${id}`,
+				).innerHTML;
 			}
 		}
 
-		return (prevLastMessage.text !== newLastMessage.text || prevLastMessage.user !== newLastMessage.user);
-	}
-	catch (error) {
-		console.warn("[bga extension] Can't process chat table", { table: chatTable.id, error });
+		return (
+			prevLastMessage.text !== newLastMessage.text ||
+			prevLastMessage.user !== newLastMessage.user
+		);
+	} catch (error) {
+		console.warn("[bga extension] Can't process chat table", {
+			table: chatTable.id,
+			error,
+		});
 		return false;
 	}
 };
 
 const muteChatAll = (config, chatContainer) => {
 	try {
-		const audioTag = document.getElementById('audiosrc_o_alt_Plop');
+		const audioTag = document.getElementById("audiosrc_o_alt_Plop");
 		if (audioTag) {
 			audioTag.muted = true;
 		}
 
-		const tables = Array.from(chatContainer.querySelectorAll('.chatwindowtype_table'));
+		const tables = Array.from(
+			chatContainer.querySelectorAll(".chatwindowtype_table"),
+		);
 		let shouldPlayPlop = false;
 
-		tables.forEach(t => shouldPlayPlop = muteChatTable(config, t) || shouldPlayPlop);
+		tables.forEach(
+			(t) =>
+				(shouldPlayPlop = muteChatTable(config, t) || shouldPlayPlop),
+		);
 
-		const prevMessages = Array.from(document.querySelectorAll('.chatwindowpreviewmsg'));
+		const prevMessages = Array.from(
+			document.querySelectorAll(".chatwindowpreviewmsg"),
+		);
 
-		prevMessages.forEach(prevMsg => {
-			const span = prevMsg.querySelector('.playername');
+		prevMessages.forEach((prevMsg) => {
+			const span = prevMsg.querySelector(".playername");
 
 			if (span) {
 				const name = span.innerHTML.trim();
@@ -285,8 +391,7 @@ const muteChatAll = (config, chatContainer) => {
 		if (shouldPlayPlop) {
 			setTimeout(playPlop, 1);
 		}
-	}
-	catch (error) {
+	} catch (error) {
 		console.warn("[bga extension] Can't process chat conversations", error);
 	}
 };
@@ -294,38 +399,42 @@ const muteChatAll = (config, chatContainer) => {
 const initChatObserver = (config) => {
 	mutedPlayers = config.getMutedPlayers();
 
-	waitForObj('#chatbar', 5).then(chatContainer => {
-		console.debug('[bga extension] init mute management', mutedPlayers);
+	waitForObj("#chatbar", 5).then((chatContainer) => {
+		console.debug("[bga extension] init mute management", mutedPlayers);
 
-		const observer = new MutationObserver(() => muteChatAll(config, chatContainer))
+		const observer = new MutationObserver(() =>
+			muteChatAll(config, chatContainer),
+		);
 		observer.observe(chatContainer, { childList: true, subtree: true });
 		return observer;
 	});
 
-	waitForObj('#audiosources', 5).then(audioContainer => {
+	waitForObj("#audiosources", 5).then((audioContainer) => {
 		const observer = new MutationObserver(() => {
-			const audioTag = document.getElementById('audiosrc_o_alt_Plop');
-			const extAudioTag = document.getElementById('ext_audiosrc_o_alt_Plop');
+			const audioTag = document.getElementById("audiosrc_o_alt_Plop");
+			const extAudioTag = document.getElementById(
+				"ext_audiosrc_o_alt_Plop",
+			);
 
 			if (audioTag) {
 				audioTag.muted = true;
 				audioTag.volume = 0;
 
 				if (!extAudioTag) {
-					extAudioTag = document.createElement('audio');
+					extAudioTag = document.createElement("audio");
 					extAudioTag.src = audioTag.src;
-					extAudioTag.id = 'ext_audiosrc_o_alt_Plop';
+					extAudioTag.id = "ext_audiosrc_o_alt_Plop";
 					audioContainer.appendChild(extAudioTag);
 				}
 			}
-		})
+		});
 		observer.observe(audioContainer, { childList: true, subtree: true });
 		return observer;
 	});
 };
 
 const initLogObserver = (config) => {
-	const logsContainer = document.querySelector('#logs');
+	const logsContainer = document.querySelector("#logs");
 
 	if (!logsContainer) {
 		return null;
@@ -335,7 +444,11 @@ const initLogObserver = (config) => {
 		if (!config.isOnlineMessagesEnabled()) {
 			logsContainer.childNodes.forEach((elt, index) => {
 				const text = elt.innerHTML;
-				if (text && text.indexOf('<!--PNS-->') >= 0 && shouldFilter(text)) {
+				if (
+					text &&
+					text.indexOf("<!--PNS-->") >= 0 &&
+					shouldFilter(text)
+				) {
 					logsContainer.removeChild(elt);
 				}
 				if (index > 20) {
@@ -359,45 +472,45 @@ const buildOption = (
 	option2,
 	toggleFunc,
 ) => {
-	const container = document.createElement('div');
-	container.className = 'preference_choice';
+	const container = document.createElement("div");
+	container.className = "preference_choice";
 
-	const row = document.createElement('div');
-	row.className = 'row-data row-data-large';
+	const row = document.createElement("div");
+	row.className = "row-data row-data-large";
 	container.appendChild(row);
 
-	const label = document.createElement('div');
-	label.className = 'row-label';
+	const label = document.createElement("div");
+	label.className = "row-label";
 	label.innerHTML = text;
 	row.appendChild(label);
 
-	const val = document.createElement('div');
-	val.className = 'row-value';
+	const val = document.createElement("div");
+	val.className = "row-value";
 	row.appendChild(val);
 
-	const input = document.createElement('select');
+	const input = document.createElement("select");
 	input.id = inputId;
-	input.className = 'preference_control';
-	input.addEventListener('click', (evt) => evt.stopPropagation());
-	input.addEventListener('change', (evt) => evt.isTrusted && toggleFunc(evt));
+	input.className = "preference_control";
+	input.addEventListener("click", (evt) => evt.stopPropagation());
+	input.addEventListener("change", (evt) => evt.isTrusted && toggleFunc(evt));
 	val.appendChild(input);
 
-	if (inputValue === '1') {
+	if (inputValue === "1") {
 		input.insertAdjacentHTML(
-			'beforeend',
+			"beforeend",
 			`<option value='1' selected='selected'>${option1}</option>`,
 		);
 		input.insertAdjacentHTML(
-			'beforeend',
+			"beforeend",
 			`<option value='0'>${option2}</option>`,
 		);
 	} else {
 		input.insertAdjacentHTML(
-			'beforeend',
+			"beforeend",
 			`<option value='1'>${option1}</option>`,
 		);
 		input.insertAdjacentHTML(
-			'beforeend',
+			"beforeend",
 			`<option value='0' selected='selected'>${option2}</option>`,
 		);
 	}
@@ -407,39 +520,45 @@ const buildOption = (
 
 const buildOptions = (config, gameName, gameConfig) => {
 	const histoInputs = [
-		document.getElementById('preference_global_control_logsSecondColumn'),
-		document.getElementById('preference_global_fontrol_logsSecondColumn'),
+		document.getElementById("preference_global_control_logsSecondColumn"),
+		document.getElementById("preference_global_fontrol_logsSecondColumn"),
 	].filter((elt) => !!elt);
-	const infobulleInput = document.getElementById('preference_control_200');
-	const mainMenu = document.getElementById('ingame_menu_content');
-	const settings = document.getElementById('pagesection_options');
+	const infobulleInput = document.getElementById("preference_control_200");
+	const mainMenu = document.getElementById("ingame_menu_content");
+	const settings = document.getElementById("pagesection_options");
 
 	if (!settings || !mainMenu || !infobulleInput || histoInputs.length !== 2) {
 		setTimeout(() => buildOptions(config, gameName, gameConfig), 500);
 		return;
 	}
 
-	const isMobile = !window.matchMedia || window.matchMedia("only screen and (max-width: 760px)").matches;
-	const mainPrefTitle = mainMenu.getElementsByTagName('h2')[0];
-	const secondPrefTitle = settings.getElementsByTagName('h2')[0];
+	const isMobile =
+		!window.matchMedia ||
+		window.matchMedia("only screen and (max-width: 760px)").matches;
+	const mainPrefTitle = mainMenu.getElementsByTagName("h2")[0];
+	const secondPrefTitle = settings.getElementsByTagName("h2")[0];
 
 	if (!isMobile) {
 		// Add an option for floating menu
-		const optionFloatingGameSelected = config.isGameFloatingMenu(gameName) ? `selected='selected'` : '';
-		const optionFloatingAlwaysSelected = config.isGlobalFloatingMenu() ? `selected='selected'` : '';
-		const optionFloatingGame = `<option value='2' ${optionFloatingGameSelected}>${chrome.i18n.getMessage('optionFloatingGame')}</option>`;
-		const optionFloatingAlways = `<option value='3' ${optionFloatingAlwaysSelected}>${chrome.i18n.getMessage('optionFloatingAlways')}</option>`;
+		const optionFloatingGameSelected = config.isGameFloatingMenu(gameName)
+			? `selected='selected'`
+			: "";
+		const optionFloatingAlwaysSelected = config.isGlobalFloatingMenu()
+			? `selected='selected'`
+			: "";
+		const optionFloatingGame = `<option value='2' ${optionFloatingGameSelected}>${chrome.i18n.getMessage("optionFloatingGame")}</option>`;
+		const optionFloatingAlways = `<option value='3' ${optionFloatingAlwaysSelected}>${chrome.i18n.getMessage("optionFloatingAlways")}</option>`;
 		const checkFloating = (evt) => {
-			if (evt.target.value === '1') {
-				document.body.classList.add('logs_on_additional_column');
+			if (evt.target.value === "1") {
+				document.body.classList.add("logs_on_additional_column");
 			} else {
-				document.body.classList.remove('logs_on_additional_column');
+				document.body.classList.remove("logs_on_additional_column");
 			}
-			if (evt.target.value === '3') {
+			if (evt.target.value === "3") {
 				setFloatingRightMenu(config, true);
 				config.setGameFloatingMenu(gameName, false);
 				config.setGlobalFloatingMenu(true);
-			} else if (evt.target.value === '2') {
+			} else if (evt.target.value === "2") {
 				setFloatingRightMenu(config, true);
 				config.setGameFloatingMenu(gameName, true);
 				config.setGlobalFloatingMenu(false);
@@ -450,29 +569,29 @@ const buildOptions = (config, gameName, gameConfig) => {
 			}
 		};
 		histoInputs.forEach((input) => {
-			input.insertAdjacentHTML('beforeend', optionFloatingGame);
-			input.insertAdjacentHTML('beforeend', optionFloatingAlways);
-			input.addEventListener('change', checkFloating);
-			input.addEventListener('click', (evt) => evt.stopPropagation());
+			input.insertAdjacentHTML("beforeend", optionFloatingGame);
+			input.insertAdjacentHTML("beforeend", optionFloatingAlways);
+			input.addEventListener("change", checkFloating);
+			input.addEventListener("click", (evt) => evt.stopPropagation());
 		});
 	}
 
 	// Add a parameter for left menu
 	if (gameConfig) {
-		const displayMenu = config.isLeftMenuEnabled(gameName) ? '1' : '0';
+		const displayMenu = config.isLeftMenuEnabled(gameName) ? "1" : "0";
 		const toggleDisplayMenu = () => {
 			const enable = !config.isLeftMenuEnabled(gameName);
 			config.setLeftMenuEnabled(gameName, enable);
 			buildLeftMenu(config, gameConfig, enable);
 			buildLeftMenuCss(gameConfig, enable);
-			document.getElementById('cde_menu_1').value = enable ? '1' : '0';
-			document.getElementById('cde_menu_2').value = enable ? '1' : '0';
+			document.getElementById("cde_menu_1").value = enable ? "1" : "0";
+			document.getElementById("cde_menu_2").value = enable ? "1" : "0";
 		};
-		const displayLeftMenuText = chrome.i18n.getMessage('optionLeftMenu');
+		const displayLeftMenuText = chrome.i18n.getMessage("optionLeftMenu");
 		buildOption(
 			mainPrefTitle,
 			displayLeftMenuText,
-			'cde_menu_1',
+			"cde_menu_1",
 			displayMenu,
 			infobulleInput[0].text,
 			infobulleInput[1].text,
@@ -481,7 +600,7 @@ const buildOptions = (config, gameName, gameConfig) => {
 		buildOption(
 			secondPrefTitle,
 			displayLeftMenuText,
-			'cde_menu_2',
+			"cde_menu_2",
 			displayMenu,
 			infobulleInput[0].text,
 			infobulleInput[1].text,
@@ -491,20 +610,20 @@ const buildOptions = (config, gameName, gameConfig) => {
 };
 
 const initChatIcon = (config) => {
-	const chatIconId = 'bga_extension_chat_icon';
+	const chatIconId = "bga_extension_chat_icon";
 
 	if (!document.getElementById(chatIconId)) {
-		waitForObj('.bga-friends-icon', 10).then((friendsElt) => {
+		waitForObj(".bga-friends-icon", 10).then((friendsElt) => {
 			const container = friendsElt.parentNode;
 
-			const chatElt = document.createElement('div');
+			const chatElt = document.createElement("div");
 			chatElt.id = chatIconId;
 			chatElt.innerHTML = `<i class='fa fa-comments' style='font-size: 32px; cursor: pointer;'></i>`;
 			chatElt.onclick = () => config.toggleGeneralChatHidden();
 			container.parentNode.insertBefore(chatElt, container);
 
-			const sepElt = document.createElement('div');
-			sepElt.className = 'ml-1 tablet:ml-6';
+			const sepElt = document.createElement("div");
+			sepElt.className = "ml-1 tablet:ml-6";
 			container.parentNode.insertBefore(sepElt, container);
 
 			setChatStyle(config);
@@ -518,20 +637,35 @@ const setStyle = (id, content) => {
 	let style = document.getElementById(chatStyleId);
 
 	if (!style) {
-		style = document.createElement('style');
+		style = document.createElement("style");
 		style.id = chatStyleId;
 		document.head.appendChild(style);
 	}
 
 	style.innerHTML = content;
-}
+};
 
 const setChatStyle = (config) => {
-	setStyle('bgaext-chat-style', config.getChatStyle());
+	setStyle("bgaext-chat-style", config.getChatStyle());
 };
 
 const setEloStyle = (config) => {
-	setStyle('bgaext-elo-style', config.getEloStyle());
+	setStyle("bgaext-elo-style", config.getEloStyle());
+};
+
+const setInProgressTableStyle = (config) => {
+	if (config.isInProgressColorfulTables()) {
+		const css = document.getElementById("bgaext-colorfultables-style");
+		if (!css) {
+			const link = document.createElement("link");
+			link.id = "bgaext-colorfultables-style";
+			link.rel = "stylesheet";
+			link.href = `${chrome.runtime.getURL(
+				"/css/colorfulTables.css",
+			)}?&time=${new Date().getTime()}`;
+			document.head.appendChild(link);
+		}
+	}
 };
 
 export {
@@ -548,5 +682,6 @@ export {
 	setChatStyle,
 	setEloStyle,
 	initDarkMode,
-	displayInformationPopup
+	displayInformationPopup,
+	setInProgressTableStyle,
 };

--- a/src/js/ui/views/OptionsView.tsx
+++ b/src/js/ui/views/OptionsView.tsx
@@ -1,422 +1,691 @@
 import React from "preact";
 import { useState } from "preact/hooks";
 
-import Configuration, { AdvancedHomeConfig, HomeConfig, InProgressConfig } from "../../config/configuration";
+import Configuration, {
+	AdvancedHomeConfig,
+	HomeConfig,
+	InProgressConfig,
+} from "../../config/configuration";
 import Switch from "../base/Switch";
 import { Button } from "../base/Button";
-import { isSoundCustom, playMp3, removeCustomMp3, uploadCustomMp3 } from "../../utils/misc/mp3";
+import {
+	isSoundCustom,
+	playMp3,
+	removeCustomMp3,
+	uploadCustomMp3,
+} from "../../utils/misc/mp3";
 
 type Props = {
-  config: Configuration,
-  onChange: () => void
+	config: Configuration;
+	onChange: () => void;
 };
 
 export const OptionsView = ({ config, onChange }: Props) => {
-  const [onlineMessages, setOnlineMessages] = useState(config.isOnlineMessagesEnabled());
-  const [eloHidden, setEloHidden] = useState(config.isEloHidden());
-  const [tracking, setTracking] = useState(config.isTrackingEnable());
-  const [soundNotification, setSoundNotification] = useState(config.isSoundNotificationEnable());
-  const [customSoundFile, setCustomSoundFile] = useState(isSoundCustom());
-  const [motionSensitivity, setMotionSensitivity] = useState(config.isMotionSensitivityEnable());
-  const [redirect, setRedirect] = useState(config.isLobbyRedirectionEnable());
-  const [autoOpen, setAutoOpen] = useState(config.isAutoOpenEnable());
-  const [solidBackground, setSolidBackground] = useState(config.isSolidBackground());
-  const [homeConfig, setHomeConfig] = useState<HomeConfig>(config.getHomeConfig());
-  const [inProgressConfig, setInProgressConfig] = useState<InProgressConfig>(config.getInProgressConfig());
-  const [hiddenGames, setHiddenGames] = useState<string[]>(config.getHiddenGames());
-  const [hiddenPlayers, setHiddenPlayers] = useState<string[]>(config.getMutedPlayers());
-  const [muteWarning, setMuteWarning] = useState(config.isMuteWarning());
-  //const [configVisible, setConfigVisible] = useState(localStorage.getItem('ext_settings') || 'about');
-  const [configVisible, setConfigVisible] = useState('about');
-  const isFirefox = window.navigator.userAgent.toLowerCase().includes('firefox');
+	const [onlineMessages, setOnlineMessages] = useState(
+		config.isOnlineMessagesEnabled(),
+	);
+	const [eloHidden, setEloHidden] = useState(config.isEloHidden());
+	const [tracking, setTracking] = useState(config.isTrackingEnable());
+	const [soundNotification, setSoundNotification] = useState(
+		config.isSoundNotificationEnable(),
+	);
+	const [customSoundFile, setCustomSoundFile] = useState(isSoundCustom());
+	const [motionSensitivity, setMotionSensitivity] = useState(
+		config.isMotionSensitivityEnable(),
+	);
+	const [redirect, setRedirect] = useState(config.isLobbyRedirectionEnable());
+	const [autoOpen, setAutoOpen] = useState(config.isAutoOpenEnable());
+	const [solidBackground, setSolidBackground] = useState(
+		config.isSolidBackground(),
+	);
+	const [homeConfig, setHomeConfig] = useState<HomeConfig>(
+		config.getHomeConfig(),
+	);
+	const [inProgressConfig, setInProgressConfig] = useState<InProgressConfig>(
+		config.getInProgressConfig(),
+	);
+	const [hiddenGames, setHiddenGames] = useState<string[]>(
+		config.getHiddenGames(),
+	);
+	const [hiddenPlayers, setHiddenPlayers] = useState<string[]>(
+		config.getMutedPlayers(),
+	);
+	const [muteWarning, setMuteWarning] = useState(config.isMuteWarning());
+	//const [configVisible, setConfigVisible] = useState(localStorage.getItem('ext_settings') || 'about');
+	const [configVisible, setConfigVisible] = useState("about");
+	const isFirefox = window.navigator.userAgent
+		.toLowerCase()
+		.includes("firefox");
 
-  const [advancedHomeConfig, setAdvancedHomeConfig] = useState<AdvancedHomeConfig>(config.getAdvancedHomeConfig());
-  const [advancedHomeHtml, setAdvancedHomeHtml] = useState(advancedHomeConfig.html);
-  const [advancedStatus, setAdvancedStatus] = useState('');
+	const [advancedHomeConfig, setAdvancedHomeConfig] =
+		useState<AdvancedHomeConfig>(config.getAdvancedHomeConfig());
+	const [advancedHomeHtml, setAdvancedHomeHtml] = useState(
+		advancedHomeConfig.html,
+	);
+	const [advancedStatus, setAdvancedStatus] = useState("");
 
-  const _updateAdvanceHomeConfig = (advConfig: AdvancedHomeConfig) => {
-    setAdvancedHomeConfig(advConfig);
-    config.setAdvancedHomeConfig(advConfig);
-  };
+	const _updateAdvanceHomeConfig = (advConfig: AdvancedHomeConfig) => {
+		setAdvancedHomeConfig(advConfig);
+		config.setAdvancedHomeConfig(advConfig);
+	};
 
-  const _setConfigVisible = (val: string) => {
-    //localStorage.setItem('ext_settings', val);
-    setConfigVisible(val);
-  };
+	const _setConfigVisible = (val: string) => {
+		//localStorage.setItem('ext_settings', val);
+		setConfigVisible(val);
+	};
 
-  const updateOnlineMessages = (val: boolean) => {
-    setOnlineMessages(val);
-    config.setOnlineMessagesEnabled(val)
-  };
+	const updateOnlineMessages = (val: boolean) => {
+		setOnlineMessages(val);
+		config.setOnlineMessagesEnabled(val);
+	};
 
-  const updateEloHidden = (val: boolean) => {
-    setEloHidden(!val);
-    config.setEloHidden(!val)
-  };
+	const updateEloHidden = (val: boolean) => {
+		setEloHidden(!val);
+		config.setEloHidden(!val);
+	};
 
-  const updateMuteWarning = (val: boolean) => {
-    setMuteWarning(val);
-    config.setMuteWarning(val)
-  };
+	const updateMuteWarning = (val: boolean) => {
+		setMuteWarning(val);
+		config.setMuteWarning(val);
+	};
 
-  const updateTracking = (val: boolean) => {
-    setTracking(val);
-    config.setTrackingEnable(val);
-    onChange();
-  };
+	const updateTracking = (val: boolean) => {
+		setTracking(val);
+		config.setTrackingEnable(val);
+		onChange();
+	};
 
-  const updateSoundNotification = (val: boolean) => {
-    setSoundNotification(val);
-    config.setSoundNotificationEnable(val)
-  };
+	const updateSoundNotification = (val: boolean) => {
+		setSoundNotification(val);
+		config.setSoundNotificationEnable(val);
+	};
 
-  const updateSoundCustom = (val: boolean) => {
-    setCustomSoundFile(val);
+	const updateSoundCustom = (val: boolean) => {
+		setCustomSoundFile(val);
 
-    if (!val) {
-      removeCustomMp3();
-    }
-  };
+		if (!val) {
+			removeCustomMp3();
+		}
+	};
 
-  const updateFlashing = (val: boolean) => {
-    setMotionSensitivity(!val);
-    config.setMotionSensitivityEnable(!val);
-  };
+	const updateFlashing = (val: boolean) => {
+		setMotionSensitivity(!val);
+		config.setMotionSensitivityEnable(!val);
+	};
 
-  const updateRedirect = (val: boolean) => {
-    setRedirect(val);
-    config.setLobbyRedirectionEnable(val);
-  };
+	const updateRedirect = (val: boolean) => {
+		setRedirect(val);
+		config.setLobbyRedirectionEnable(val);
+	};
 
-  const updateAutoOpen = (val: boolean) => {
-    setAutoOpen(val);
-    config.setAutoOpenEnable(val);
-  };
+	const updateAutoOpen = (val: boolean) => {
+		setAutoOpen(val);
+		config.setAutoOpenEnable(val);
+	};
 
-  const updateSolidBackground = (val: boolean) => {
-    setSolidBackground(val);
-    config.setSolidBackground(val);
-  };
+	const updateSolidBackground = (val: boolean) => {
+		setSolidBackground(val);
+		config.setSolidBackground(val);
+	};
 
-  const updateHomeConfig = (param: string, val: boolean) => {
-    const newHomeConfig = { ...homeConfig, [param]: val };
-    setHomeConfig(newHomeConfig);
-    config.setHomeConfig(newHomeConfig);
-    onChange();
-  };
+	const updateHomeConfig = (param: string, val: boolean) => {
+		const newHomeConfig = { ...homeConfig, [param]: val };
+		setHomeConfig(newHomeConfig);
+		config.setHomeConfig(newHomeConfig);
+		onChange();
+	};
 
-  const updateInProgressConfig = (param: string, val: boolean) => {
-    const newInProgressConfig = { ...inProgressConfig, [param]: val };
-    setInProgressConfig(newInProgressConfig);
-    config.setInProgressConfig(newInProgressConfig);
-    onChange();
-  };
+	const updateInProgressConfig = (param: string, val: boolean) => {
+		const newInProgressConfig = { ...inProgressConfig, [param]: val };
+		setInProgressConfig(newInProgressConfig);
+		config.setInProgressConfig(newInProgressConfig);
+		onChange();
+	};
 
-  const getHiddenConfiguration = () => {
-    if (!hiddenGames.length) {
-      return (
-        <span>
-          {chrome.i18n.getMessage("optionNoHiddenGames")}
-        </span>
-      );
-    }
+	const getHiddenConfiguration = () => {
+		if (!hiddenGames.length) {
+			return <span>{chrome.i18n.getMessage("optionNoHiddenGames")}</span>;
+		}
 
-    return hiddenGames.map((game, index) => (
-      <div
-        className="bgext_hidden_game"
-        key={`game_${index}`}
-      >
-        {game}
-        <div className="bgext_hidden_game_close" onClick={() => setHiddenGames(config.displayGame(game))}>🗙</div>
-      </div>
-    ));
-  };
+		return hiddenGames.map((game, index) => (
+			<div className="bgext_hidden_game" key={`game_${index}`}>
+				{game}
+				<div
+					className="bgext_hidden_game_close"
+					onClick={() => setHiddenGames(config.displayGame(game))}
+				>
+					🗙
+				</div>
+			</div>
+		));
+	};
 
-  const getMutedConfiguration = () => {
-    if (!hiddenPlayers.length) {
-      return (
-        <span>
-          {chrome.i18n.getMessage("optionNoMutedPlayer")}
-        </span>
-      );
-    }
+	const getMutedConfiguration = () => {
+		if (!hiddenPlayers.length) {
+			return <span>{chrome.i18n.getMessage("optionNoMutedPlayer")}</span>;
+		}
 
-    return hiddenPlayers.map((name, index) => (
-      <div
-        className="bgext_hidden_game"
-        key={`hidden_player_${index}`}
-      >
-        {name}
-        <div className="bgext_hidden_game_close" onClick={() => setHiddenPlayers(config.unmutePlayer(name))}>🗙</div>
-      </div>
-    ));
-  };
+		return hiddenPlayers.map((name, index) => (
+			<div className="bgext_hidden_game" key={`hidden_player_${index}`}>
+				{name}
+				<div
+					className="bgext_hidden_game_close"
+					onClick={() => setHiddenPlayers(config.unmutePlayer(name))}
+				>
+					🗙
+				</div>
+			</div>
+		));
+	};
 
-  const arrow = () => {
-    return (
-      <svg xmlns="http://www.w3.org/2000/svg">
-        <path fill="currentcolor" d="M12 17.414 3.293 8.707l1.414-1.414L12 14.586l7.293-7.293 1.414 1.414L12 17.414z" />
-      </svg>
-    );
-  };
+	const arrow = () => {
+		return (
+			<svg xmlns="http://www.w3.org/2000/svg">
+				<path
+					fill="currentcolor"
+					d="M12 17.414 3.293 8.707l1.414-1.414L12 14.586l7.293-7.293 1.414 1.414L12 17.414z"
+				/>
+			</svg>
+		);
+	};
 
-  const getSwitch = (checked: boolean, onChange: (val: boolean) => void, textOnKey: string, textOffKey: string, disabled?: boolean) => {
-    const textOn = chrome.i18n.getMessage(textOnKey);
-    const textOff = chrome.i18n.getMessage(textOffKey);
-    const msg = checked ? textOn : textOff;
-    const className = (msg.length > 73) ? 'long_text' : undefined;
+	const getSwitch = (
+		checked: boolean,
+		onChange: (val: boolean) => void,
+		textOnKey: string,
+		textOffKey: string,
+		disabled?: boolean,
+	) => {
+		const textOn = chrome.i18n.getMessage(textOnKey);
+		const textOff = chrome.i18n.getMessage(textOffKey);
+		const msg = checked ? textOn : textOff;
+		const className = msg.length > 73 ? "long_text" : undefined;
 
-    return <Switch checked={checked} textOn={textOn} textOff={textOff} onChange={onChange} disabled={disabled} className={className} />
-  };
+		return (
+			<Switch
+				checked={checked}
+				textOn={textOn}
+				textOff={textOff}
+				onChange={onChange}
+				disabled={disabled}
+				className={className}
+			/>
+		);
+	};
 
-  const getMiscSection = () => {
-    if (configVisible === 'misc') {
-      return (
-        <div className="options-frame">
-          <div className="options-frame-title">{chrome.i18n.getMessage("optionMiscTitle")}</div>
-          {getSwitch(tracking, updateTracking, "optionsTrackingOn", "optionsTrackingOff")}
-          {!isFirefox && getSwitch(soundNotification && tracking, updateSoundNotification, "optionsNotificationSoundOn", "optionsNotificationSoundOff", !tracking)}
-          {!isFirefox && <div className="row_fullwidth">
-            {getSwitch(soundNotification && tracking && customSoundFile, updateSoundCustom, "optionsNotificationCustomSoundOn", "optionsNotificationCustomSoundOff", !tracking || !soundNotification)}
-            {tracking && soundNotification && <div>
-              {customSoundFile && <Button {...{ text: chrome.i18n.getMessage("uploadMp3"), className: "small_button", onClick: uploadCustomMp3 }} />}
-              <Button {...{ text: chrome.i18n.getMessage("play"), className: "small_button", onClick: playMp3 }}
-              />
-            </div>}
-          </div>}
-          {getSwitch(!motionSensitivity, updateFlashing, "optionsFlashingOn", "optionsFlashingOff")}
-          {getSwitch(redirect, updateRedirect, "optionsLobbyRedirectOn", "optionsLobbyRedirectOff")}
-          {getSwitch(autoOpen, updateAutoOpen, "optionsAutoOpenOn", "optionsAutoOpenOff")}
-          {getSwitch(solidBackground, updateSolidBackground, "optionsSolidBackgroundOn", "optionsSolidBackgroundOff")}
-        </div>
-      );
-    }
+	const getMiscSection = () => {
+		if (configVisible === "misc") {
+			return (
+				<div className="options-frame">
+					<div className="options-frame-title">
+						{chrome.i18n.getMessage("optionMiscTitle")}
+					</div>
+					{getSwitch(
+						tracking,
+						updateTracking,
+						"optionsTrackingOn",
+						"optionsTrackingOff",
+					)}
+					{!isFirefox &&
+						getSwitch(
+							soundNotification && tracking,
+							updateSoundNotification,
+							"optionsNotificationSoundOn",
+							"optionsNotificationSoundOff",
+							!tracking,
+						)}
+					{!isFirefox && (
+						<div className="row_fullwidth">
+							{getSwitch(
+								soundNotification &&
+									tracking &&
+									customSoundFile,
+								updateSoundCustom,
+								"optionsNotificationCustomSoundOn",
+								"optionsNotificationCustomSoundOff",
+								!tracking || !soundNotification,
+							)}
+							{tracking && soundNotification && (
+								<div>
+									{customSoundFile && (
+										<Button
+											{...{
+												text: chrome.i18n.getMessage(
+													"uploadMp3",
+												),
+												className: "small_button",
+												onClick: uploadCustomMp3,
+											}}
+										/>
+									)}
+									<Button
+										{...{
+											text: chrome.i18n.getMessage(
+												"play",
+											),
+											className: "small_button",
+											onClick: playMp3,
+										}}
+									/>
+								</div>
+							)}
+						</div>
+					)}
+					{getSwitch(
+						!motionSensitivity,
+						updateFlashing,
+						"optionsFlashingOn",
+						"optionsFlashingOff",
+					)}
+					{getSwitch(
+						redirect,
+						updateRedirect,
+						"optionsLobbyRedirectOn",
+						"optionsLobbyRedirectOff",
+					)}
+					{getSwitch(
+						autoOpen,
+						updateAutoOpen,
+						"optionsAutoOpenOn",
+						"optionsAutoOpenOff",
+					)}
+					{getSwitch(
+						solidBackground,
+						updateSolidBackground,
+						"optionsSolidBackgroundOn",
+						"optionsSolidBackgroundOff",
+					)}
+				</div>
+			);
+		}
 
-    return (
-      <div className="options-frame reduced" onClick={() => _setConfigVisible('misc')}>
-        <div className="options-frame-title">{chrome.i18n.getMessage("optionMiscTitle")} {arrow()}</div>
-      </div>
-    );
-  };
+		return (
+			<div
+				className="options-frame reduced"
+				onClick={() => _setConfigVisible("misc")}
+			>
+				<div className="options-frame-title">
+					{chrome.i18n.getMessage("optionMiscTitle")} {arrow()}
+				</div>
+			</div>
+		);
+	};
 
-  const getGamesSection = () => {
-    if (configVisible === 'games') {
-      return (
-        <div className="options-frame">
-          <div className="options-frame-title">{chrome.i18n.getMessage("optionGamesTitle")}</div>
-          {getSwitch(onlineMessages, updateOnlineMessages, "optionFriendsActivityOn", "optionFriendsActivityOff")}
-          {getSwitch(!eloHidden, updateEloHidden, "optionEloHiddenOff", "optionEloHiddenOn")}
-        </div>
-      );
-    }
+	const getGamesSection = () => {
+		if (configVisible === "games") {
+			return (
+				<div className="options-frame">
+					<div className="options-frame-title">
+						{chrome.i18n.getMessage("optionGamesTitle")}
+					</div>
+					{getSwitch(
+						onlineMessages,
+						updateOnlineMessages,
+						"optionFriendsActivityOn",
+						"optionFriendsActivityOff",
+					)}
+					{getSwitch(
+						!eloHidden,
+						updateEloHidden,
+						"optionEloHiddenOff",
+						"optionEloHiddenOn",
+					)}
+				</div>
+			);
+		}
 
-    return (
-      <div className="options-frame reduced" onClick={() => _setConfigVisible('games')}>
-        <div className="options-frame-title">{chrome.i18n.getMessage("optionGamesTitle")} {arrow()}</div>
-      </div>
-    );
-  };
+		return (
+			<div
+				className="options-frame reduced"
+				onClick={() => _setConfigVisible("games")}
+			>
+				<div className="options-frame-title">
+					{chrome.i18n.getMessage("optionGamesTitle")} {arrow()}
+				</div>
+			</div>
+		);
+	};
 
-  const getHomeSwitch = (param: string, message: string) => {
-    return getSwitch(homeConfig[param], (val) => updateHomeConfig(param, val), `${message}On`, `${message}Off`);
-  };
+	const getHomeSwitch = (param: string, message: string) => {
+		return getSwitch(
+			homeConfig[param],
+			(val) => updateHomeConfig(param, val),
+			`${message}On`,
+			`${message}Off`,
+		);
+	};
 
-  const getAdvancedCommand = () => {
-    if (advancedHomeConfig.advanced) {
-      const saveHtml = () => {
-        const domParser = new DOMParser();
-        const doc = domParser.parseFromString(`<div>${advancedHomeHtml}</div>`, 'application/xml');
-        const parseError = doc.documentElement.querySelector('parsererror');
+	const getAdvancedCommand = () => {
+		if (advancedHomeConfig.advanced) {
+			const saveHtml = () => {
+				const domParser = new DOMParser();
+				const doc = domParser.parseFromString(
+					`<div>${advancedHomeHtml}</div>`,
+					"application/xml",
+				);
+				const parseError =
+					doc.documentElement.querySelector("parsererror");
 
-        if (parseError !== null && parseError.nodeType === Node.ELEMENT_NODE) {
-          console.debug("[bga extension] Html parse error", parseError);
-          setAdvancedStatus('error');
-        } else {
-          _updateAdvanceHomeConfig({ html: advancedHomeHtml, advanced: advancedHomeConfig.advanced })
-          setAdvancedStatus('saved');
-        }
-        setTimeout(() => setAdvancedStatus(''), 2000);
-      };
+				if (
+					parseError !== null &&
+					parseError.nodeType === Node.ELEMENT_NODE
+				) {
+					console.debug(
+						"[bga extension] Html parse error",
+						parseError,
+					);
+					setAdvancedStatus("error");
+				} else {
+					_updateAdvanceHomeConfig({
+						html: advancedHomeHtml,
+						advanced: advancedHomeConfig.advanced,
+					});
+					setAdvancedStatus("saved");
+				}
+				setTimeout(() => setAdvancedStatus(""), 2000);
+			};
 
-      if (advancedStatus == '') {
-        return (
-          <div className="options-buttons-container">
-            <button
-              className="bg-bgaBlue hover:bg-bgaBlue-light options-button"
-              onClick={() => window.open(chrome.i18n.getMessage('htmlHelpPage'), "_blank")}
-            >
-              {chrome.i18n.getMessage('buttonHelp')}
-            </button>
-            <button
-              className="bg-bgaBlue hover:bg-bgaBlue-light options-button"
-              onClick={saveHtml}
-            >
-              {chrome.i18n.getMessage('buttonSave')}
-            </button>
-          </div>
-        );
-      }
+			if (advancedStatus == "") {
+				return (
+					<div className="options-buttons-container">
+						<button
+							className="bg-bgaBlue hover:bg-bgaBlue-light options-button"
+							onClick={() =>
+								window.open(
+									chrome.i18n.getMessage("htmlHelpPage"),
+									"_blank",
+								)
+							}
+						>
+							{chrome.i18n.getMessage("buttonHelp")}
+						</button>
+						<button
+							className="bg-bgaBlue hover:bg-bgaBlue-light options-button"
+							onClick={saveHtml}
+						>
+							{chrome.i18n.getMessage("buttonSave")}
+						</button>
+					</div>
+				);
+			}
 
-      const text = chrome.i18n.getMessage(advancedStatus == 'saved' ? 'htmlSaved' : 'htmlError');
-      return <div className={`options-buttons-container ${advancedStatus}`}>{text}</div>;
-    }
+			const text = chrome.i18n.getMessage(
+				advancedStatus == "saved" ? "htmlSaved" : "htmlError",
+			);
+			return (
+				<div className={`options-buttons-container ${advancedStatus}`}>
+					{text}
+				</div>
+			);
+		}
 
-    return <></>;
-  };
+		return <></>;
+	};
 
-  const getDetailedHomeSection = () => {
-    if (advancedHomeConfig.advanced) {
-      return <textarea
-        className="options-textarea"
-        value={advancedHomeHtml}
-        onChange={(evt: any) => setAdvancedHomeHtml(evt.target.value)}
-      />;
-    }
+	const getDetailedHomeSection = () => {
+		if (advancedHomeConfig.advanced) {
+			return (
+				<textarea
+					className="options-textarea"
+					value={advancedHomeHtml}
+					onChange={(evt: any) =>
+						setAdvancedHomeHtml(evt.target.value)
+					}
+				/>
+			);
+		}
 
-    return (
-      <>
-        <div className="options-subframe">
-          <div>
-            {getHomeSwitch('header', 'optionsHomeHeader')}
-            {getHomeSwitch('latestNews', 'optionsHomeLatest')}
-            {getHomeSwitch('smallFeed', 'optionsHomeNewsSmall')}
-            {getSwitch(homeConfig.fewFeeds && homeConfig.tournaments && homeConfig.tournamentsBelow, (val) => updateHomeConfig('fewFeeds', val), "optionsHomeNewsShort", "optionsHomeNewsTall", !homeConfig.tournaments || !homeConfig.tournamentsBelow)}
-            {getHomeSwitch('tournaments', 'tournaments')}
-            {getSwitch(homeConfig.tournamentsBelow && homeConfig.tournaments, (val) => updateHomeConfig('tournamentsBelow', val), "tournamentsBelowOn", "tournamentsBelowOff", !homeConfig.tournaments)}
-            {getHomeSwitch('howToPlay', 'optionsHomeHowToPlay')}
-          </div>
-          <div>
-            {getHomeSwitch('recentGames', 'optionsRecentColumn')}
-            {getHomeSwitch('popularGames', 'optionsPopularColumn')}
-            {getHomeSwitch('recommandedGames', 'optionsRecommendedColumn')}
-            {getHomeSwitch('classicGames', 'optionsClassicGames')}
-            {getSwitch(homeConfig.events || homeConfig.recentGames, (val) => updateHomeConfig('events', val), "optionsHomeEventsOn", "optionsHomeEventsOff", homeConfig.recentGames)}
-            {getHomeSwitch('status', 'optionsStatus')}
-            {getHomeSwitch('footer', 'optionsHomeFooter')}
-          </div>
-        </div>
-      </>
-    );
-  };
+		return (
+			<>
+				<div className="options-subframe">
+					<div>
+						{getHomeSwitch("header", "optionsHomeHeader")}
+						{getHomeSwitch("latestNews", "optionsHomeLatest")}
+						{getHomeSwitch("smallFeed", "optionsHomeNewsSmall")}
+						{getSwitch(
+							homeConfig.fewFeeds &&
+								homeConfig.tournaments &&
+								homeConfig.tournamentsBelow,
+							(val) => updateHomeConfig("fewFeeds", val),
+							"optionsHomeNewsShort",
+							"optionsHomeNewsTall",
+							!homeConfig.tournaments ||
+								!homeConfig.tournamentsBelow,
+						)}
+						{getHomeSwitch("tournaments", "tournaments")}
+						{getSwitch(
+							homeConfig.tournamentsBelow &&
+								homeConfig.tournaments,
+							(val) => updateHomeConfig("tournamentsBelow", val),
+							"tournamentsBelowOn",
+							"tournamentsBelowOff",
+							!homeConfig.tournaments,
+						)}
+						{getHomeSwitch("howToPlay", "optionsHomeHowToPlay")}
+					</div>
+					<div>
+						{getHomeSwitch("recentGames", "optionsRecentColumn")}
+						{getHomeSwitch("popularGames", "optionsPopularColumn")}
+						{getHomeSwitch(
+							"recommandedGames",
+							"optionsRecommendedColumn",
+						)}
+						{getHomeSwitch("classicGames", "optionsClassicGames")}
+						{getSwitch(
+							homeConfig.events || homeConfig.recentGames,
+							(val) => updateHomeConfig("events", val),
+							"optionsHomeEventsOn",
+							"optionsHomeEventsOff",
+							homeConfig.recentGames,
+						)}
+						{getHomeSwitch("status", "optionsStatus")}
+						{getHomeSwitch("footer", "optionsHomeFooter")}
+					</div>
+				</div>
+			</>
+		);
+	};
 
-  const getHomeSection = () => {
-    if (configVisible === 'home') {
-      return (
-        <div className="options-frame">
-          <div className="options-frame-title">{chrome.i18n.getMessage("optionsHome")}</div>
-          <div className="row_fullwidth">
-            {getSwitch(advancedHomeConfig.advanced, () => _updateAdvanceHomeConfig({ html: advancedHomeConfig.html, advanced: !advancedHomeConfig.advanced }), "optionsHomeAdvancedOn", "optionsHomeAdvancedOff")}
-            {getAdvancedCommand()}
-          </div>
-          {getDetailedHomeSection()}
-          <div>{chrome.i18n.getMessage("optionsHomeRefresh")}</div>
-        </div>
-      );
-    }
+	const getHomeSection = () => {
+		if (configVisible === "home") {
+			return (
+				<div className="options-frame">
+					<div className="options-frame-title">
+						{chrome.i18n.getMessage("optionsHome")}
+					</div>
+					<div className="row_fullwidth">
+						{getSwitch(
+							advancedHomeConfig.advanced,
+							() =>
+								_updateAdvanceHomeConfig({
+									html: advancedHomeConfig.html,
+									advanced: !advancedHomeConfig.advanced,
+								}),
+							"optionsHomeAdvancedOn",
+							"optionsHomeAdvancedOff",
+						)}
+						{getAdvancedCommand()}
+					</div>
+					{getDetailedHomeSection()}
+					<div>{chrome.i18n.getMessage("optionsHomeRefresh")}</div>
+				</div>
+			);
+		}
 
-    return (
-      <div className="options-frame reduced" onClick={() => _setConfigVisible('home')}>
-        <div className="options-frame-title">{chrome.i18n.getMessage("optionsHome")} {arrow()}</div>
-      </div>
-    );
-  };
+		return (
+			<div
+				className="options-frame reduced"
+				onClick={() => _setConfigVisible("home")}
+			>
+				<div className="options-frame-title">
+					{chrome.i18n.getMessage("optionsHome")} {arrow()}
+				</div>
+			</div>
+		);
+	};
 
-  const getInProgressSwitch = (param: string, message: string) => {
-    return getSwitch(inProgressConfig[param], (val) => updateInProgressConfig(param, val), `${message}On`, `${message}Off`);
-  };
+	const getInProgressSwitch = (param: string, message: string) => {
+		return getSwitch(
+			inProgressConfig[param],
+			(val) => updateInProgressConfig(param, val),
+			`${message}On`,
+			`${message}Off`,
+		);
+	};
 
-  const getInProgressSection = () => {
-    if (configVisible === 'inProgress') {
-      return (
-        <div className="options-frame">
-          <div className="options-frame-title">{chrome.i18n.getMessage("optionsInProgress")}</div>
-          <div className="options-subframe">
-            <div>
-              {getInProgressSwitch('emptySections', 'optionsInProgressEmpty')}
-              {getInProgressSwitch('discover', 'optionsInProgressDiscover')}
-            </div>
-            <div>
-              {getInProgressSwitch('playAgain', 'optionsInProgressReplay')}
-              {getInProgressSwitch('more', 'optionsInProgressMore')}
-            </div>
-          </div>
-        </div>
-      );
-    }
+	const getInProgressSection = () => {
+		if (configVisible === "inProgress") {
+			return (
+				<div className="options-frame">
+					<div className="options-frame-title">
+						{chrome.i18n.getMessage("optionsInProgress")}
+					</div>
+					<div className="options-subframe">
+						<div>
+							{getInProgressSwitch(
+								"emptySections",
+								"optionsInProgressEmpty",
+							)}
+							{getInProgressSwitch(
+								"discover",
+								"optionsInProgressDiscover",
+							)}
+							{getInProgressSwitch(
+								"colorfulTables",
+								"optionsInProgressColorfulTables",
+							)}
+						</div>
+						<div>
+							{getInProgressSwitch(
+								"playAgain",
+								"optionsInProgressReplay",
+							)}
+							{getInProgressSwitch(
+								"more",
+								"optionsInProgressMore",
+							)}
+						</div>
+					</div>
+				</div>
+			);
+		}
 
-    return (
-      <div className="options-frame reduced" onClick={() => _setConfigVisible('inProgress')}>
-        <div className="options-frame-title">{chrome.i18n.getMessage("optionsInProgress")} {arrow()}</div>
-      </div>
-    );
-  };
+		return (
+			<div
+				className="options-frame reduced"
+				onClick={() => _setConfigVisible("inProgress")}
+			>
+				<div className="options-frame-title">
+					{chrome.i18n.getMessage("optionsInProgress")} {arrow()}
+				</div>
+			</div>
+		);
+	};
 
-  const getHiddenGamesSection = () => {
-    if (configVisible === 'hidden') {
-      return (
-        <div className="options-frame">
-          <div className="options-frame-title">{chrome.i18n.getMessage("optionHiddenTab")}</div>
-          <div>{chrome.i18n.getMessage("optionHiddenGamesWarning")}</div>
-          <div className="bgext_hidden_games_container">{getHiddenConfiguration()}</div>
-        </div>
-      );
-    }
+	const getHiddenGamesSection = () => {
+		if (configVisible === "hidden") {
+			return (
+				<div className="options-frame">
+					<div className="options-frame-title">
+						{chrome.i18n.getMessage("optionHiddenTab")}
+					</div>
+					<div>
+						{chrome.i18n.getMessage("optionHiddenGamesWarning")}
+					</div>
+					<div className="bgext_hidden_games_container">
+						{getHiddenConfiguration()}
+					</div>
+				</div>
+			);
+		}
 
-    return (
-      <div className="options-frame reduced" onClick={() => _setConfigVisible('hidden')}>
-        <div className="options-frame-title">{chrome.i18n.getMessage("optionHiddenTab")} {arrow()}</div>
-      </div>
-    );
-  };
+		return (
+			<div
+				className="options-frame reduced"
+				onClick={() => _setConfigVisible("hidden")}
+			>
+				<div className="options-frame-title">
+					{chrome.i18n.getMessage("optionHiddenTab")} {arrow()}
+				</div>
+			</div>
+		);
+	};
 
-  const getHiddenPlayersSection = () => {
-    if (configVisible === 'muted') {
-      return (
-        <div className="options-frame">
-          <div className="options-frame-title">{chrome.i18n.getMessage("optionMutedTab")}</div>
-          <div>{chrome.i18n.getMessage("optionMutedWarning")}</div>
-          <div className="col">
-            <div className="bgext_hidden_games_container">{getMutedConfiguration()}</div>
-            {getSwitch(muteWarning, updateMuteWarning, "muteWarningOn", "muteWarningOff")}
-          </div>
-        </div>
-      );
-    }
+	const getHiddenPlayersSection = () => {
+		if (configVisible === "muted") {
+			return (
+				<div className="options-frame">
+					<div className="options-frame-title">
+						{chrome.i18n.getMessage("optionMutedTab")}
+					</div>
+					<div>{chrome.i18n.getMessage("optionMutedWarning")}</div>
+					<div className="col">
+						<div className="bgext_hidden_games_container">
+							{getMutedConfiguration()}
+						</div>
+						{getSwitch(
+							muteWarning,
+							updateMuteWarning,
+							"muteWarningOn",
+							"muteWarningOff",
+						)}
+					</div>
+				</div>
+			);
+		}
 
-    return (
-      <div className="options-frame reduced" onClick={() => _setConfigVisible('muted')}>
-        <div className="options-frame-title">{chrome.i18n.getMessage("optionMutedTab")} {arrow()}</div>
-      </div>
-    );
-  };
+		return (
+			<div
+				className="options-frame reduced"
+				onClick={() => _setConfigVisible("muted")}
+			>
+				<div className="options-frame-title">
+					{chrome.i18n.getMessage("optionMutedTab")} {arrow()}
+				</div>
+			</div>
+		);
+	};
 
-  const getAboutSection = () => {
-    if (configVisible === 'about') {
-      return (
-        <div className="options-frame">
-          <div className="options-frame-title">{chrome.i18n.getMessage("about")}</div>
-          <div dangerouslySetInnerHTML={{ __html: chrome.i18n.getMessage("aboutText") }}></div>
-          <div className="options-version">Version {chrome.runtime.getManifest().version}</div>
-        </div>
-      );
-    }
+	const getAboutSection = () => {
+		if (configVisible === "about") {
+			return (
+				<div className="options-frame">
+					<div className="options-frame-title">
+						{chrome.i18n.getMessage("about")}
+					</div>
+					<div
+						dangerouslySetInnerHTML={{
+							__html: chrome.i18n.getMessage("aboutText"),
+						}}
+					></div>
+					<div className="options-version">
+						Version {chrome.runtime.getManifest().version}
+					</div>
+				</div>
+			);
+		}
 
-    return (
-      <div className="options-frame reduced" onClick={() => _setConfigVisible('about')}>
-        <div className="options-frame-title">{chrome.i18n.getMessage("about")} {arrow()}</div>
-      </div>
-    );
-  };
+		return (
+			<div
+				className="options-frame reduced"
+				onClick={() => _setConfigVisible("about")}
+			>
+				<div className="options-frame-title">
+					{chrome.i18n.getMessage("about")} {arrow()}
+				</div>
+			</div>
+		);
+	};
 
-  return (
-    <div className="options-container">
-      {getMiscSection()}
-      {getGamesSection()}
-      {getHomeSection()}
-      {getInProgressSection()}
-      {getHiddenGamesSection()}
-      {getHiddenPlayersSection()}
-      {getAboutSection()}
-    </div>
-  );
+	return (
+		<div className="options-container">
+			{getMiscSection()}
+			{getGamesSection()}
+			{getHomeSection()}
+			{getInProgressSection()}
+			{getHiddenGamesSection()}
+			{getHiddenPlayersSection()}
+			{getAboutSection()}
+		</div>
+	);
 };

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,87 +1,72 @@
 {
-  "manifest_version": 3,
-  "name": "Board Game Arena (BGA) Extension",
-  "short_name": "BGA Extension",
-  "version": "1.11.3",
-  "action": {
-    "default_popup": "popup.html"
-  },
-  "options_ui": {
-    "page": "options.html"
-  },
-  "default_locale": "en",
-  "description": "__MSG_ext_description__",
-  "icons": {
-    "16": "img/icon-16.png",
-    "48": "img/icon-48.png",
-    "128": "img/icon-128.png"
-  },
-  "content_scripts": [
-    {
-      "matches": [
-        "https://boardgamearena.com/*",
-        "https://studio.boardgamearena.com/*"
-      ],
-      "run_at": "document_start",
-      "js": [
-        "content.js"
-      ],
-      "all_frames": true
-    },
-    {
-      "matches": [
-        "https://forum.boardgamearena.com/*"
-      ],
-      "run_at": "document_start",
-      "js": [
-        "contentForum.js"
-      ],
-      "all_frames": true
-    }
-  ],
-  "author": "Flavien Busseuil & Christophe Delaforge",
-  "homepage_url": "https://github.com/FlavienBusseuil/bga-chrome-extension",
-  "background": {
-    "scripts": [
-      "background.js"
-    ]
-  },
-  "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'"
-  },
-  "host_permissions": [
-    "https://*.boardgamearena.com/*/*",
-    "https://*.boardgamearena.net/*/*"
-  ],
-  "permissions": [
-    "alarms",
-    "storage",
-    "declarativeNetRequestWithHostAccess"
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": [
-        "img/anim-*.png",
-        "img/loading.gif",
-        "img/icon-48.png",
-        "img/icon-grey.png",
-        "css/dark_theme/*.css",
-        "css/light_theme/*.css",
-        "js/homepage.js",
-        "js/bgaApi.js"
-      ],
-      "extension_ids": [
-        "*"
-      ],
-      "matches": [
-        "<all_urls>"
-      ]
-    }
-  ],
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "{e0c7f997-ef08-4a68-8636-1e22206fe4fc}",
-      "strict_min_version": "113.0"
-    }
-  }
+	"manifest_version": 3,
+	"name": "Board Game Arena (BGA) Extension",
+	"short_name": "BGA Extension",
+	"version": "1.11.3",
+	"action": {
+		"default_popup": "popup.html"
+	},
+	"options_ui": {
+		"page": "options.html"
+	},
+	"default_locale": "en",
+	"description": "__MSG_ext_description__",
+	"icons": {
+		"16": "img/icon-16.png",
+		"48": "img/icon-48.png",
+		"128": "img/icon-128.png"
+	},
+	"content_scripts": [
+		{
+			"matches": [
+				"https://boardgamearena.com/*",
+				"https://studio.boardgamearena.com/*"
+			],
+			"run_at": "document_start",
+			"js": ["content.js"],
+			"all_frames": true
+		},
+		{
+			"matches": ["https://forum.boardgamearena.com/*"],
+			"run_at": "document_start",
+			"js": ["contentForum.js"],
+			"all_frames": true
+		}
+	],
+	"author": "Flavien Busseuil & Christophe Delaforge",
+	"homepage_url": "https://github.com/FlavienBusseuil/bga-chrome-extension",
+	"background": {
+		"scripts": ["background.js"]
+	},
+	"content_security_policy": {
+		"extension_pages": "script-src 'self'; object-src 'self'"
+	},
+	"host_permissions": [
+		"https://*.boardgamearena.com/*/*",
+		"https://*.boardgamearena.net/*/*"
+	],
+	"permissions": ["alarms", "storage", "declarativeNetRequestWithHostAccess"],
+	"web_accessible_resources": [
+		{
+			"resources": [
+				"img/anim-*.png",
+				"img/loading.gif",
+				"img/icon-48.png",
+				"img/icon-grey.png",
+				"css/dark_theme/*.css",
+				"css/light_theme/*.css",
+				"css/colorfulTables.css",
+				"js/homepage.js",
+				"js/bgaApi.js"
+			],
+			"extension_ids": ["*"],
+			"matches": ["<all_urls>"]
+		}
+	],
+	"browser_specific_settings": {
+		"gecko": {
+			"id": "{e0c7f997-ef08-4a68-8636-1e22206fe4fc}",
+			"strict_min_version": "113.0"
+		}
+	}
 }

--- a/src/manifest-opera.json
+++ b/src/manifest-opera.json
@@ -1,88 +1,79 @@
 {
-  "manifest_version": 3,
-  "name": "Board Game Arena (BGA) Extension",
-  "short_name": "BGA",
-  "version": "1.11.3",
-  "action": {
-    "default_popup": "popup.html"
-  },
-  "options_ui": {
-    "page": "options.html"
-  },
-  "default_locale": "en",
-  "description": "__MSG_ext_description__",
-  "icons": {
-    "16": "img/icon-16.png",
-    "48": "img/icon-48.png",
-    "128": "img/icon-128.png"
-  },
-  "content_scripts": [
-    {
-      "matches": [
-        "https://boardgamearena.com/*",
-        "https://studio.boardgamearena.com/*"
-      ],
-      "run_at": "document_start",
-      "js": [
-        "content.js"
-      ],
-      "all_frames": true
-    },
-    {
-      "matches": [
-        "https://forum.boardgamearena.com/*"
-      ],
-      "run_at": "document_start",
-      "js": [
-        "contentForum.js"
-      ],
-      "all_frames": true
-    }
-  ],
-  "author": "Flavien Busseuil & Christophe Delaforge",
-  "homepage_url": "https://github.com/FlavienBusseuil/bga-chrome-extension",
-  "background": {
-    "service_worker": "background.js",
-    "type": "module"
-  },
-  "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'"
-  },
-  "host_permissions": [
-    "https://*.boardgamearena.com/*/*",
-    "https://*.boardgamearena.net/*/*"
-  ],
-  "permissions": [
-    "alarms",
-    "storage",
-    "declarativeNetRequestWithHostAccess",
-    "offscreen"
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": [
-        "img/anim-*.png",
-        "img/loading.gif",
-        "img/icon-48.png",
-        "img/icon-grey.png",
-        "css/dark_theme/*.css",
-        "css/light_theme/*.css",
-        "js/homepage.js",
-        "js/bgaApi.js",
-        "sound/myturn.mp3",
-        "offscreen.html"
-      ],
-      "extension_ids": [
-        "*"
-      ],
-      "matches": [
-        "<all_urls>"
-      ]
-    }
-  ],
-  "browser_specific_settings": {
-    "edge": {
-      "browser_action_next_to_addressbar": true
-    }
-  }
+	"manifest_version": 3,
+	"name": "Board Game Arena (BGA) Extension",
+	"short_name": "BGA",
+	"version": "1.11.3",
+	"action": {
+		"default_popup": "popup.html"
+	},
+	"options_ui": {
+		"page": "options.html"
+	},
+	"default_locale": "en",
+	"description": "__MSG_ext_description__",
+	"icons": {
+		"16": "img/icon-16.png",
+		"48": "img/icon-48.png",
+		"128": "img/icon-128.png"
+	},
+	"content_scripts": [
+		{
+			"matches": [
+				"https://boardgamearena.com/*",
+				"https://studio.boardgamearena.com/*"
+			],
+			"run_at": "document_start",
+			"js": ["content.js"],
+			"all_frames": true
+		},
+		{
+			"matches": ["https://forum.boardgamearena.com/*"],
+			"run_at": "document_start",
+			"js": ["contentForum.js"],
+			"all_frames": true
+		}
+	],
+	"author": "Flavien Busseuil & Christophe Delaforge",
+	"homepage_url": "https://github.com/FlavienBusseuil/bga-chrome-extension",
+	"background": {
+		"service_worker": "background.js",
+		"type": "module"
+	},
+	"content_security_policy": {
+		"extension_pages": "script-src 'self'; object-src 'self'"
+	},
+	"host_permissions": [
+		"https://*.boardgamearena.com/*/*",
+		"https://*.boardgamearena.net/*/*"
+	],
+	"permissions": [
+		"alarms",
+		"storage",
+		"declarativeNetRequestWithHostAccess",
+		"offscreen"
+	],
+	"web_accessible_resources": [
+		{
+			"resources": [
+				"img/anim-*.png",
+				"img/loading.gif",
+				"img/icon-48.png",
+				"img/icon-grey.png",
+				"css/dark_theme/*.css",
+				"css/light_theme/*.css",
+				"css/colorfulTables.css",
+				"js/homepage.js",
+				"js/bgaApi.js",
+				"sound/myturn.mp3",
+				"offscreen.html"
+			],
+			"extension_ids": ["*"],
+			"matches": ["<all_urls>"]
+		}
+	],
+	"browser_specific_settings": {
+		"edge": {
+			"browser_action_next_to_addressbar": true
+		}
+	}
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,88 +1,79 @@
 {
-  "manifest_version": 3,
-  "name": "Board Game Arena (BGA) Chrome Extension - boardgamearena.com",
-  "short_name": "BGA Chrome Extension",
-  "version": "1.11.3",
-  "action": {
-    "default_popup": "popup.html"
-  },
-  "options_ui": {
-    "page": "options.html"
-  },
-  "default_locale": "en",
-  "description": "__MSG_ext_description__",
-  "icons": {
-    "16": "img/icon-16.png",
-    "48": "img/icon-48.png",
-    "128": "img/icon-128.png"
-  },
-  "content_scripts": [
-    {
-      "matches": [
-        "https://boardgamearena.com/*",
-        "https://studio.boardgamearena.com/*"
-      ],
-      "run_at": "document_start",
-      "js": [
-        "content.js"
-      ],
-      "all_frames": true
-    },
-    {
-      "matches": [
-        "https://forum.boardgamearena.com/*"
-      ],
-      "run_at": "document_start",
-      "js": [
-        "contentForum.js"
-      ],
-      "all_frames": true
-    }
-  ],
-  "author": "Flavien Busseuil & Christophe Delaforge",
-  "homepage_url": "https://github.com/FlavienBusseuil/bga-chrome-extension",
-  "background": {
-    "service_worker": "background.js",
-    "type": "module"
-  },
-  "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'"
-  },
-  "host_permissions": [
-    "https://*.boardgamearena.com/*/*",
-    "https://*.boardgamearena.net/*/*"
-  ],
-  "permissions": [
-    "alarms",
-    "storage",
-    "declarativeNetRequestWithHostAccess",
-    "offscreen"
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": [
-        "img/anim-*.png",
-        "img/loading.gif",
-        "img/icon-48.png",
-        "img/icon-grey.png",
-        "css/dark_theme/*.css",
-        "css/light_theme/*.css",
-        "js/homepage.js",
-        "js/bgaApi.js",
-        "sound/myturn.mp3",
-        "offscreen.html"
-      ],
-      "extension_ids": [
-        "*"
-      ],
-      "matches": [
-        "<all_urls>"
-      ]
-    }
-  ],
-  "browser_specific_settings": {
-    "edge": {
-      "browser_action_next_to_addressbar": true
-    }
-  }
+	"manifest_version": 3,
+	"name": "Board Game Arena (BGA) Chrome Extension - boardgamearena.com",
+	"short_name": "BGA Chrome Extension",
+	"version": "1.11.3",
+	"action": {
+		"default_popup": "popup.html"
+	},
+	"options_ui": {
+		"page": "options.html"
+	},
+	"default_locale": "en",
+	"description": "__MSG_ext_description__",
+	"icons": {
+		"16": "img/icon-16.png",
+		"48": "img/icon-48.png",
+		"128": "img/icon-128.png"
+	},
+	"content_scripts": [
+		{
+			"matches": [
+				"https://boardgamearena.com/*",
+				"https://studio.boardgamearena.com/*"
+			],
+			"run_at": "document_start",
+			"js": ["content.js"],
+			"all_frames": true
+		},
+		{
+			"matches": ["https://forum.boardgamearena.com/*"],
+			"run_at": "document_start",
+			"js": ["contentForum.js"],
+			"all_frames": true
+		}
+	],
+	"author": "Flavien Busseuil & Christophe Delaforge",
+	"homepage_url": "https://github.com/FlavienBusseuil/bga-chrome-extension",
+	"background": {
+		"service_worker": "background.js",
+		"type": "module"
+	},
+	"content_security_policy": {
+		"extension_pages": "script-src 'self'; object-src 'self'"
+	},
+	"host_permissions": [
+		"https://*.boardgamearena.com/*/*",
+		"https://*.boardgamearena.net/*/*"
+	],
+	"permissions": [
+		"alarms",
+		"storage",
+		"declarativeNetRequestWithHostAccess",
+		"offscreen"
+	],
+	"web_accessible_resources": [
+		{
+			"resources": [
+				"img/anim-*.png",
+				"img/loading.gif",
+				"img/icon-48.png",
+				"img/icon-grey.png",
+				"css/dark_theme/*.css",
+				"css/light_theme/*.css",
+				"css/colorfulTables.css",
+				"js/homepage.js",
+				"js/bgaApi.js",
+				"sound/myturn.mp3",
+				"offscreen.html"
+			],
+			"extension_ids": ["*"],
+			"matches": ["<all_urls>"]
+		}
+	],
+	"browser_specific_settings": {
+		"edge": {
+			"browser_action_next_to_addressbar": true
+		}
+	}
 }


### PR DESCRIPTION
I was inspired by your extension and wanted to add some of the custom css work I've done to it. Would this be something you would be willing to merge in?

I added a new option:
![image](https://github.com/user-attachments/assets/b19af552-2c28-4ff6-93ef-a2ebce9b8cdb)

When enabled, the game tables on the In Progress page (and within the side bar) look like this depending on whether light or dark mode is turned on:
![image](https://github.com/user-attachments/assets/a6e0e39d-f75d-430c-b985-aeb9198a8b0b)
![image](https://github.com/user-attachments/assets/3d781f9e-8abf-4204-93a0-926c25b3cb36)

![image](https://github.com/user-attachments/assets/02803830-7723-4903-a3bf-2ee51e716c47)
![image](https://github.com/user-attachments/assets/eabd092d-24ae-4758-828c-b7d720b8e338)

![image](https://github.com/user-attachments/assets/cb05f9ce-c1cb-4180-b011-1f58326e53ca)
![image](https://github.com/user-attachments/assets/052248fe-4748-4164-9bad-90c5fb76b001)

Note: I'm not sure why Prettier decided to update so much of the formatting of the files I added to 🫤