### PR TITLE
French tarot and nanatoridori dark theme fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn-error*
 keys/**
 .parcel-cache
 /local/
+.vs

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -314,7 +314,7 @@
 		"message": "Le jeu n'apparaitra plus dans la liste des jeux ni dans le lobby."
 	},
 	"deleteGameText2": {
-		"message": "Ceci n'est pas une fonctionnalité du site Board Game Arena mais un ajout géré par une extension que vous avez installé."
+		"message": "Ceci n'est pas une fonctionnalité du site Board Game Arena mais un ajout géré par une extension que vous avez installée."
 	},
 	"deleteGameText3": {
 		"message": "Il est possible d'annuler la suppression d'un jeu dans les paramètres de l'extension."

--- a/src/css/dark_theme/general.css
+++ b/src/css/dark_theme/general.css
@@ -2206,3 +2206,7 @@ html:not(.bgaext_gamelist) .ext_delete_button {
 .bgaext_premium .odd\:bg-gray-100:nth-child(odd) {
   background-color: var(--dark-30);
 }
+
+.own-progress-old-season-description {
+  color: white
+}

--- a/src/js/config/darkThemeGames.ts
+++ b/src/js/config/darkThemeGames.ts
@@ -3155,7 +3155,7 @@ body { background: none !important; }
 `;
 
 _darkStyleForGame['frenchtarot'] = `
-#icon_first_player_in_panel { filter: invert(1); }
+.icon.first_player { filter: invert(1); }
 .#000 { text-shadow: var(--text-w-shadow); }
 #score_table thead th, #score_table tfoot th, #score_table tfoot td, #score_table tbody tr:nth-of-type(2n)>* { background-color: var(--dark-20) !important; }
 .black { text-shadow: var(--text-w-shadow); }
@@ -4755,6 +4755,7 @@ _darkStyleForGame['nanatoridori'] = `
 #overall-content:before { content: ""; background: #000000A0; position: absolute; width: 100%; height: 100%; }
 #overall-content { color: var(--light-80); }
 .nana_hand { color: #000; }
+.scorecell.score { color: black }
 `;
 
 _darkStyleForGame['nangaparbat'] = `


### PR DESCRIPTION
Tarot: the first player icon is also displayed on the board, and this one wasn't affected by the previous rule, making it almost invisible there.

Nanatoridori: scores in the scores popup (accessible via the button above the player panels) were written in white on a white background.

Arena: old season's own results were written in black on a black background, making them hardly readable