### PR TITLE
Add German translation

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,0 +1,589 @@
+{
+	"ext_description": {
+		"message": "Verwalte deine laufenden Spiele und füge viele visuelle Verbesserungen hinzu (Dunker Modus, uvm.)."
+	},
+	"something_wrong": {
+		"message": "Etwas ist schiefgelaufen! 😭"
+	},
+	"report_error": {
+		"message": "Du kannst Fehler im <a target='_blank' href='https://boardgamearena.com/forum/viewtopic.php?t=30509'>Forum</a> melden."
+	},
+	"report_error_ff": {
+		"message": "Stelle sicher, dass du der Erweiterung alle nötigen Berechtigung erteilt hast (rechtsklick auf auf das Icon der Erweiterung, dann \"Erweiteruzng verwalten\" und öffne den \"Berechtigungen\" Tab). Falls du den diesen Fehler nicht alleine beheben kannst, kontaktiere uns bitte im <a target='_blank' href='https://boardgamearena.com/forum/viewtopic.php?t=30509'>Forum</a>."
+	},
+	"play_new_game": {
+		"message": "Starte ein neues Spiel"
+	},
+	"please_login": {
+		"message": "Bitte melden dich an"
+	},
+	"player_invited_you": {
+		"message": "$player$ hat dich eingeladen",
+		"placeholders": {
+			"player": {
+				"content": "$1"
+			}
+		}
+	},
+	"realtime": {
+		"message": "Echtzeit"
+	},
+	"turn_based": {
+		"message": "Zugbasiert"
+	},
+	"tournament": {
+		"message": "Turnier"
+	},
+	"arena": {
+		"message": "Arena"
+	},
+	"training": {
+		"message": "Training"
+	},
+	"accept": {
+		"message": "Annehmen"
+	},
+	"decline": {
+		"message": "Ablehnen"
+	},
+	"play_tournament": {
+		"message": "Für ein Turnier ammelden"
+	},
+	"tables": {
+		"message": "Tische"
+	},
+	"tournaments": {
+		"message": "Turniere"
+	},
+	"no_games": {
+		"message": "Keine laufenden Spiele"
+	},
+	"no_tournaments": {
+		"message": "Keine Turniere"
+	},
+	"optionRemoveLogTimestampsOn": {
+		"message": "Zeitstempel werde aus dem Spiel-Log entfernt"
+	},
+	"optionRemoveLogTimestampsOff": {
+		"message": "Zeitstempel werden im Spiele-Log angezeigt (Standard-Verhalten)"
+	},
+	"optionFriendsActivityOn": {
+		"message": "Die Aktivitäten deiner Freunde werden in den Spiel-Logs angezeigt"
+	},
+	"optionFriendsActivityOff": {
+		"message": "Die Aktivitäten deiner Freunde werden in den Spiel-Logs ausgeblendet"
+	},
+	"optionEloHiddenOn": {
+		"message": "Der ELO-Wert der Spieler wird in Spielen ausgeblendet"
+	},
+	"optionEloHiddenOff": {
+		"message": "Der ELO-Wert der Spieler wird in Spielen angezeigt"
+	},
+	"optionLeftMenu": {
+		"message": "Navigiere zwischen den Spieler Bereichen"
+	},
+	"optionFloatingGame": {
+		"message": "Als schwebendes Menü (nur für dieses Spiel)"
+	},
+	"optionFloatingAlways": {
+		"message": "Als schwebendes Menü (für alle Spiele)"
+	},
+	"optionMisc": {
+		"message": "Sonstiges"
+	},
+	"optionDisplay": {
+		"message": "Benutzerdefinierte Anzeige"
+	},
+	"optionHiddenTab": {
+		"message": "Ausgeblendete Spiele"
+	},
+	"optionHiddenOn": {
+		"message": "Die Option zum Ausblenden eines Spiels ist aktiviert"
+	},
+	"optionHiddenOff": {
+		"message": "Die Option zum Ausblenden eines Spiels ist deaktiviert"
+	},
+	"optionMutedTab": {
+		"message": "Stumm geschaltete Spieler"
+	},
+	"optionNavigationTab": {
+		"message": "Navigation-Seiten-Menü"
+	},
+	"optionCssTab": {
+		"message": "Benutzerdefiniertes CSS"
+	},
+	"optionMiscTitle": {
+		"message": "Sonstiges"
+	},
+	"optionNotifTitle": {
+		"message": "Benachrichtigungen"
+	},
+	"optionGamesTitle": {
+		"message": "Spiele-Parameters"
+	},
+	"optionHiddenTitle": {
+		"message": "Liste ausgeblendeter Spiele"
+	},
+	"optionNavigationTitle": {
+		"message": "Verwaltete Spiele-Liste"
+	},
+	"optionCssTitle": {
+		"message": "Passe das Aussehen der Seite mit CSS Code an"
+	},
+	"optionNoHiddenGames": {
+		"message": "Keine ausgeblendeten Spiele"
+	},
+	"optionsClearHiddenGames": {
+		"message": "Leere die Liste ausgeblendeter Spiele"
+	},
+	"optionsClearHiddenGamesConfirm": {
+		"message": "Der Inhalt der obigen Liste wird gelöscht"
+	},
+	"optionHiddenGamesWarning": {
+		"message": "Entferne ein Spiel von der Liste, um es wieder auf Board Game Arena anzuzeigen. (Du musst die Seite neu laden, um die Änderung anzuwenden)"
+	},
+	"optionNoMutedPlayer": {
+		"message": "Keine stumm geschalteten Spieler."
+	},
+	"optionMutedWarning": {
+		"message": "Du kannst bis zu 10 Spieler stumm schalten. Entferne Spieler, um die Stummschaltung aufzuheben."
+	},
+	"optionNavigationWarning": {
+		"message": "Warnung: ändere die Einstellungen auf dieser Seite nur, wenn du weisst was du tust ;)"
+	},
+	"optionDuplicate": {
+		"message": "Duplizieren"
+	},
+	"optionReset": {
+		"message": "Zurücksetzen"
+	},
+	"optionDelete": {
+		"message": "Löschen"
+	},
+	"optionSave": {
+		"message": "Speichern"
+	},
+	"sideMenuMainBoard": {
+		"message": "Hauptbereich"
+	},
+	"reportCreationWarning": {
+		"message": "Du verwendest eine Browser-Erweiterung, die das Aussehen der Seite und mancher Spiele signifikant verändert. Falls du Probleme mit <a href='https://en.doc.boardgamearena.com/ChromeExtension' target='_blank' class='bga-link'>Funktionen der Erweiterung</a> hast, erstelle bitte keine BGA-Fehlermeldung, sondern melde diese im Forumsbeitrag der Erweiterung!"
+	},
+	"reportCreationWarningLink": {
+		"message": "HIER"
+	},
+	"reportCreationWarningCss": {
+		"message": "Du hast zusätzlich den CSS code der Seite über die Erweiterung angepasst, überprüfe deshalbt das deine Änderungen nicht zu den Problemen führen."
+	},
+	"darkColorConfigurationMain": {
+		"message": "Standard Farben"
+	},
+	"darkColorResetMain": {
+		"message": "Dunkler Modus ohne Farben"
+	},
+	"darkColorConfigurationGame": {
+		"message": "Spiel-Farb-Einstellungen"
+	},
+	"darkColorResetGame": {
+		"message": "Standard Farben der Seite"
+	},
+	"darkColorRecommanded": {
+		"message": "Vorgeschlagene Farben"
+	},
+	"friends": {
+		"message": "Freunde-Tische"
+	},
+	"no_games_friends": {
+		"message": "Keine laufenden Spiele verfügbar"
+	},
+	"search_games_friends": {
+		"message": "Suche nach offenen Tischen von Freunden oder deiner Gruppen-Mitglieder."
+	},
+	"search": {
+		"message": "Suche"
+	},
+	"options": {
+		"message": "Einstellungen"
+	},
+	"optionsTrackingOn": {
+		"message": "Tisch-Statusmeldung aktiviert (andere Spieler sehen, dass du online bist)"
+	},
+	"optionsTrackingOff": {
+		"message": "Tisch-Statusmeldung deaktiviert"
+	},
+	"optionsNotificationSoundOn": {
+		"message": "Tonbenachrichtigung, wenn du an mindestens einem Tisch erwartet wirst"
+	},
+	"optionsNotificationSoundOff": {
+		"message": "Tonbenachrichtigung deaktiviert"
+	},
+	"optionsNotificationCustomSoundOn": {
+		"message": "Eigner Ton"
+	},
+	"optionsNotificationCustomSoundOff": {
+		"message": "Standard Ton"
+	},
+	"optionsFlashingOn": {
+		"message": "Tische, an denen du erwartet wirst, werden durch eine blinkende Färbung hervorgehoben"
+	},
+	"optionsFlashingOff": {
+		"message": "Tische, an denen du erwartet wirst, werden durch eine Nachricht und Färbung hervorgehoben"
+	},
+	"optionsLobbyRedirectOn": {
+		"message": "Hyperlinks werden angepasst, um auf die klassische  Lobby zu verweisen (wenn möglich)"
+	},
+	"optionsLobbyRedirectOff": {
+		"message": "Hyperlinks werden nicht angepasst, die Standard-Lobby wird verwendet (normalerweise die Neue)"
+	},
+	"optionsFastCreate": {
+		"message": "Schnelle-Tisch-Erstellung"
+	},
+	"optionsFastCreateOn": {
+		"message": "Eine Schaltfläche zum schnellen Erstellen eines Tisches wird neben der klassischen Schaltfläche zum Erstellen hinzugefügt"
+	},
+	"optionsFastCreateOff": {
+		"message": "Schnelle-Tisch-Erstellung ist deaktiviert"
+	},
+	"optionsFastCreateAutoOpenOn": {
+		"message": "Die 'Schnelle Erstellung' Schaltfläche öffnet den Tisch automatisch für andere Spieler"
+	},
+	"optionsFastCreateAutoOpenOff": {
+		"message": "Die 'Schnelle Erstellung' Schaltfläche öffnet den Tisch nicht für andere Spieler"
+	},
+	"optionsFastCreateKarmaOn": {
+		"message": "Spieler mit schlechter Reputation (< 75%) werden ausgeschlossen [BETA]"
+	},
+	"optionsFastCreateKarmaOff": {
+		"message": "Deine letztgenutzen Reputationskriterien werden verwendet"
+	},
+	"optionsFastCreateLevelOn": {
+		"message": "Die folgenden Level Restriktionen werden verwendet [BETA]"
+	},
+	"optionsFastCreateLevelOff": {
+		"message": "Deine zuletzt genutzen Level-Restriktionen werden verwendet"
+	},
+	"optionsFastCreateLevel0": {
+		"message": "Spieler stärker als ich werden ausgeschlossen"
+	},
+	"optionsFastCreateLevel1": {
+		"message": "Nur Spieler mit meinem Level ±1 werden akzeptiert"
+	},
+	"optionsFastCreateLevel2": {
+		"message": "Nur Spieler mit meinem Level ±2 werden akzeptiert"
+	},
+	"optionsSolidBackgroundOn": {
+		"message": "Der Standard-Hintergrund (Holzpaletten) wird durch einen einfarbigen Hintergrund ersetzt"
+	},
+	"optionsSolidBackgroundOff": {
+		"message": "Der Standard-Hintergrund (Holzpaletten) wird verwendet"
+	},
+	"optionsHideSocialMessagesOn": {
+		"message": "Der News-Feed beinhaltet nur Gruppen-Nachrichten"
+	},
+	"optionsHideSocialMessagesOff": {
+		"message": "Der News-Feed beinhaltet alle Nachrichten"
+	},
+	"optionsAnimatedTitleOn": {
+		"message": "Dem Seitentitel in Browser-Tabs wird eine Animation vorangestellt, wenn du an der Reihe bist zu spielen (Standardverhalten)"
+	},
+	"optionsAnimatedTitleOff": {
+		"message": "Seitentitel in Browser-Tabs werden nicht animiert"
+	},
+	"optionsChatUserNameOn": {
+		"message": "Nutzernamen werden im Chat immer angezeigt"
+	},
+	"optionsChatUserNameOff": {
+		"message": "Nutzernamen werden im Chat, nur wenn nötig angezeigt"
+	},
+	"optionsChatDarkIconsOn": {
+		"message": "Emoticons im dunklen Modus werden in Unterhaltungen verwendet, wenn der dunkle Modus aktiviert ist"
+	},
+	"optionsChatDarkIconsOff": {
+		"message": "Emoticons im hellen Modus werden in Unterhaltungen verwendet, auch wenn der dunkle Modus aktiviert ist"
+	},
+	"optionsChatAutoHideOn": {
+		"message": "Die Chatleiste wird nur angezeigt, wenn die Maus darüber bewegt wird"
+	},
+	"optionsChatAutoHideOff": {
+		"message": "Die Chatleiste wird immer angezeigt"
+	},
+	"about": {
+		"message": "Über"
+	},
+	"aboutText": {
+		"message": "<p>Du findest die Hilfeseite der Erweiterung auf <a target='_blank' href='https://en.doc.boardgamearena.com/ChromeExtension'>dieser Seite</a>.</p><p>Alternativ kannst du dich direkt mit den Entwicklern im <a target='_blank' href='https://boardgamearena.com/forum/viewtopic.php?t=30509'>Forum</a> austauschen, wir freuen uns über deine Anmerkungen und Vorschläge, oder ein paar Worte der Ermutigung. 🙂</p><p>Und falls du diese Erweiterung magst, kannst du mir gerne einen <a target='_blank' href='https://en.tipeee.com/board-game-arena-chrome-extension'>Kaffee</a> ☕ ausgeben.</p><p>Vielen Dank!</p>"
+	},
+	"deleteGameTitle": {
+		"message": "Vestecke ein Spiel"
+	},
+	"deleteGameText1": {
+		"message": "Dieses Spiel wird nicht mehr in der Spiele-Liste oder Lobby angezeigt."
+	},
+	"deleteGameText2": {
+		"message": "Dies ist keine Funktion von Board Game Arena, sondern eine Funktion einer Browser-Erweiterung, die du installiert hast."
+	},
+	"deleteGameText3": {
+		"message": "Du kannst das Ausblenden eines Spieles über die Einstellung der Browser-Erweiterung zurücksetzen."
+	},
+	"deleteGameLink": {
+		"message": "<a target='_blank' href='https://en.doc.boardgamearena.com/ChromeExtension'>Siehe Dokumentation</a>"
+	},
+	"deleteStop": {
+		"message": "Zeige diese Nachricht nicht erneut an"
+	},
+	"fastStartTitle": {
+		"message": "Schneller Start eines Spiels"
+	},
+	"fastStartText1": {
+		"message": "Das Spiel wird direkt mit den Standard-Optionen gestartet(und automatisch für andere Spieler geöffnet, wenn du diese Option gesetzt hast)."
+	},
+	"mutePlayerTitle": {
+		"message": "Einen Spieler stumm schalten"
+	},
+	"muteText1": {
+		"message": "Du erhältst keine weiteren Nachrichten von einem stumm geschalteten Spieler. Du kannst bis zu 10 Spieler stumm schalten und die Liste in den Optionen der Erweiterung verwalten."
+	},
+	"muteWarningOn": {
+		"message": "Benachrichtige andere Spiele über deine Entscheidung, einen Spieler stummzuschalten."
+	},
+	"muteWarningOff": {
+		"message": "Benachrichtige niemanden über deine Entscheidung, einen Spieler stummzuschalten."
+	},
+	"buttonConfirm": {
+		"message": "Bestätigen"
+	},
+	"buttonCancel": {
+		"message": "Abbrechen"
+	},
+	"buttonClose": {
+		"message": "Schließen"
+	},
+	"buttonLater": {
+		"message": "Erinnere mich später"
+	},
+	"my_friends": {
+		"message": "Meine Freunde"
+	},
+	"optionsHome": {
+		"message": "Hauptseite"
+	},
+	"optionsHomeHeaderOn": {
+		"message": "Kopfzeile wird angezeigt"
+	},
+	"optionsHomeHeaderOff": {
+		"message": "Kopfzeile wird ausgeblendet"
+	},
+	"optionsHomeFooterOn": {
+		"message": "Fußzeile wird angezeigt"
+	},
+	"optionsHomeFooterOff": {
+		"message": "Fußzeile wird ausgeblendet"
+	},
+	"optionsHomeLatestOn": {
+		"message": "Neuigkeiten werden angezeigt"
+	},
+	"optionsHomeLatestOff": {
+		"message": "Neuigkeiten werden ausgeblendet"
+	},
+	"optionsHomeNewsSmallOff": {
+		"message": "Großer News-Feed"
+	},
+	"optionsHomeNewsSmallOn": {
+		"message": "Kleiner News-Feed"
+	},
+	"optionsHomeEventsOn": {
+		"message": "Spiele-Kalender anzeigen"
+	},
+	"optionsHomeEventsOff": {
+		"message": "Spiele-Kalender ausgeblendet"
+	},
+	"optionsHomeHowToPlayOn": {
+		"message": "\"Wie spielt man ...\" anzeigen"
+	},
+	"optionsHomeHowToPlayOff": {
+		"message": "\"Wie spielt man ...\" ausblenden"
+	},
+	"tournamentsOn": {
+		"message": "Turniere anzeigen"
+	},
+	"tournamentsOff": {
+		"message": "Turniere ausblenden"
+	},
+	"tournamentsBelowOn": {
+		"message": "Turniere über Neuigkeiten"
+	},
+	"tournamentsBelowOff": {
+		"message": "Turniere auf der rechten Seite"
+	},
+	"optionsRecentColumnOn": {
+		"message": "Neue Spiele anzeigen"
+	},
+	"optionsRecentColumnOff": {
+		"message": "Neue Spiele ausblenden"
+	},
+	"optionsPopularColumnOn": {
+		"message": "Beliebte Spiele angezeigen"
+	},
+	"optionsPopularColumnOff": {
+		"message": "Beliebte Spiele ausblenden"
+	},
+	"optionsRecommendedColumnOn": {
+		"message": "Empfohlene Spiele einblenden"
+	},
+	"optionsRecommendedColumnOff": {
+		"message": "Empfohlene Spiele ausblenden"
+	},
+	"optionsClassicGamesOn": {
+		"message": "Klassiker einblenden"
+	},
+	"optionsClassicGamesOff": {
+		"message": "Klassiker ausblenden"
+	},
+	"optionsStatusOn": {
+		"message": "Service Status einblende"
+	},
+	"optionsStatusOff": {
+		"message": "Service Status ausblenden"
+	},
+	"optionsHomeNewsShort": {
+		"message": "Kurzer Nachrichten-Feed"
+	},
+	"optionsHomeNewsTall": {
+		"message": "Langer Nachrichten-Feed"
+	},
+	"optionsHomeRefresh": {
+		"message": "Falls es nach Änderungen der Einstellung zu Anzeigefehlern kommt, lade die Seite neu."
+	},
+	"optionsInProgress": {
+		"message": "Laufende Spiele"
+	},
+	"optionsInProgressEmptyOn": {
+		"message": "'Auf dem Laufenden' Bereich anzeigen"
+	},
+	"optionsInProgressEmptyOff": {
+		"message": "'Auf dem Laufenden' Bereich ausblenden"
+	},
+	"optionsInProgressReplayOn": {
+		"message": "'Wiederholungen' Bereich anzeigen"
+	},
+	"optionsInProgressReplayOff": {
+		"message": "'Wiederholungen' Bereich ausblenden"
+	},
+	"optionsInProgressDiscoverOn": {
+		"message": "'Entdecke andere Spiele' Bereich anzeigen"
+	},
+	"optionsInProgressDiscoverOff": {
+		"message": "'Entdecke andere Spiele' Bereich ausblenden"
+	},
+	"optionsInProgressMoreOn": {
+		"message": "'Mehr Freunde' Bereich einblenden"
+	},
+	"optionsInProgressMoreOff": {
+		"message": "'Mehr Freunde' Bereich ausblenden"
+	},
+	"optionsInProgressColorfulTablesOn": {
+		"message": "Farbigere Tisch-Hintergründe"
+	},
+	"optionsInProgressColorfulTablesOff": {
+		"message": "Standard Tisch-Farben"
+	},
+	"optionsHomeAdvancedOn": {
+		"message": "Erweiterte Konfiguration"
+	},
+	"optionsHomeAdvancedOff": {
+		"message": "Einfache Konfiguration"
+	},
+	"uploadMp3": {
+		"message": "MP3 hochladen"
+	},
+	"play": {
+		"message": "Abspielen"
+	},
+	"buttonSave": {
+		"message": "Speichern"
+	},
+	"buttonHelp": {
+		"message": "Hilfe"
+	},
+	"htmlError": {
+		"message": "Ungültiger HTML Code"
+	},
+	"htmlSaved": {
+		"message": "HTML Code gespeichert"
+	},
+	"htmlHelpPage": {
+		"message": "https://en.doc.boardgamearena.com/ChromeExtension#Advanced_home_page_settings"
+	},
+	"infosTitleChrome": {
+		"message": "Informationen über die 'BGA Chrome Extension'"
+	},
+	"infosTitleFirefox": {
+		"message": "Informationen über die 'BGA Firefox Extension'"
+	},
+	"infosSubTitleChrome": {
+		"message": "Danke für die Nutzung der BGA Chrome Extension!"
+	},
+	"infosSubTitleFirefox": {
+		"message": "Danke für die Nutzung der BGA Firefox Extension!"
+	},
+	"infosLine1": {
+		"message": "Bist du auf dem Laufenden bezüglich neuer Erweiterungs-Funktionen?"
+	},
+	"infosLine2": {
+		"message": "Zum Beispiel, die Möglichkeit Spieler im Chat stummzuschalten, oder ein eigenes HTML Template für die Anzeige der Hauptseiten-Elemente zu definieren?"
+	},
+	"infosLine3": {
+		"message": "Falls du immer über neue Funktionen der Erweiterung informiert werden möchtest, tritt der <a target='_blank' href='https://boardgamearena.com/group?id=17718382' class='bga-link'>Browser Extension Users</a> Gruppe bei, um über den BGA News-Feed informiert zu bleiben."
+	},
+	"infosLine4": {
+		"message": "Natürlich kannst du auch jederzeit die <a target='_blank' href='https://en.doc.boardgamearena.com/ChromeExtension' class='bga-link'>Erweiterungs-Dokumentation</a> betrachten und dich mit den Entwicklern im <a target='_blank' href='https://boardgamearena.com/forum/viewtopic.php?t=30509' class='bga-link'>Forum</a> austauschen."
+	},
+	"infosLine5": {
+		"message": "Viel Spaß!"
+	},
+	"troubleshooting": {
+		"message": "Fehlersuche"
+	},
+	"configurationExport": {
+		"message": "Exportiere die aktuelle Konfiguration"
+	},
+	"configurationImport": {
+		"message": "Importiere die aktuelle Konfiguration"
+	},
+	"configurationReset": {
+		"message": "Setzte die Konfiguration auf die Standardwerte zurück"
+	},
+	"configurationExported": {
+		"message": "Die Konfiguration wurde als .json Datei in deinen Downloads Ordner exportiert"
+	},
+	"configurationImported": {
+		"message": "Die Konfiguration wurde erfolgreich importiert"
+	},
+	"configurationRestored": {
+		"message": "Standard-Einstellungen wurden wiederhergestellt"
+	},
+	"bugReportTitle": {
+		"message": "Melde einen Fehler des dunklen Modus"
+	},
+	"bugReportButtonCreate": {
+		"message": "Melde einen Fehler"
+	},
+	"bugReportButtonSend": {
+		"message": "Sende den Fehlerbericht"
+	},
+	"bugReportButtonCancel": {
+		"message": "Abbrechen"
+	},
+	"bugReportDescription": {
+		"message": "Beschreibung (beschreibe das Problem und wie man dieses reproduzieren kann)"
+	},
+	"bugReportScreenshot": {
+		"message": "Screenshot (du kannst diesen auf <a href='https://imgur.com/' target='_blank' class='bga-ext-link' >Imgur.com</a> hochladen und hier den Link einfügen)"
+	},
+	"bugReportResult": {
+		"message": "Dein Fehlerbericht wurde abgeschickt. Du kannst den aktuellen Status des Berichts auf <a href='/group?id=18063230' target='_blank' class='bga-ext-link'>dieser Seite</a> verfolgen. "
+	},
+	"bugReportNew": {
+		"message": "Neu! Du kannst Fehler im dunklen Modus nun direkt hier über das Pop-Up melden"
+	}
+}


### PR DESCRIPTION
I choose to use informal language here (You = "du" instead of the formal "Sie") as I believe it better fits the context of the extension.

Additionally, I've shortened some translations (e.g., friends) to make them fit into the existing UI elements' space. And altered some phrasings (e.g. optionsInProgressEmptyOn) to make them less ambiguous for German speakers.

Checked for typos and grammar issues using LanguageTool.

### Additional concerns

- Some German users may prefer to continue using the extension in English. May need to add an option to do so, which is not that simple given that chromium and gecko handle things differently
- **Long-term maintenance**: I'll try to continue updating the German translation as long as I'm actively using the extension. For new strings, I believe most German users will be fine if they default to the English values at first until a proper translation is added.