### PR TITLE
Fix nav side menu options not working at Firefox

### DIFF
--- a/src/css/options.css
+++ b/src/css/options.css
@@ -194,8 +194,22 @@ textarea.options-textarea {
 		font-size: 14px;
 	}
 
-	#bgext_options_tab_navigation {
-		display: none;
+	.bgext_options_container {
+		padding: 0 5px;
+	}
+
+	.bgext_options_gameconfig_container {
+		height: 350px;
+		width: 100%;
+	}
+
+	.bgext_options_gamelist_container {
+		height: 350px;
+	}
+
+	.bgext_options_warning {
+		text-align: center;
+		padding: 0;
 	}
 }
 

--- a/src/js/config/configuration.ts
+++ b/src/js/config/configuration.ts
@@ -207,6 +207,9 @@ class Configuration {
 				}
 			} catch (error) { } // not a big deal
 		});
+
+		// Return explicitly to ensure everything is done
+		return true;
 	}
 
 	private _merge() {


### PR DESCRIPTION
With Firefox config.init() for some reason gets resolved before _init is completed if we do not return explicitly causing the navigation side menu options tab to not render properly.

Adjusted CSS as well to take smaller width of firefox extensions options menu into account.