### PR TITLE
Improve light theme flashing fix

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -32,14 +32,13 @@ let chatbardock = undefined;
 if (localStorage.getItem('ext_dark_theme') === 'on') {
 	// hack to avoid light theme flashing
 	const s = document.createElement('style');
-	s.innerHTML = "* { visibility: hidden; }"
+	s.innerHTML = `html { background: #000000 !important; }
+			body { visability: hidden !important; }`;
 	document.documentElement.appendChild(s);
 	window.addEventListener("load", () => {
-		if (window.navigator.userAgent.toLowerCase().includes('firefox')) {
-			setTimeout(() => { s.remove(); }, 500);
-		} else {
+		setTimeout(() => {
 			s.remove();
-		}
+		}, 0);
 	});
 }
 
@@ -403,7 +402,9 @@ document.addEventListener('bga_ext_update_config', (data) => {
 window.addEventListener('message', (evt) => {
 	if (evt.origin === 'https://forum.boardgamearena.com' && evt.data.key === 'bga_ext_forum_visible') {
 		// hack to avoid light theme flashing
-		console.debug('[bga extension] forum displayed');
-		document.documentElement.classList.add('bgaext_forum_visible');
+		setTimeout(() => {
+			console.debug('[bga extension] forum displayed');
+			document.documentElement.classList.add('bgaext_forum_visible');
+		}, 0);
 	}
 }, false);


### PR DESCRIPTION
Avoid displaying the forum before the dark theme CSS has been fully injected. Additionally, coloring the website black before CSS injection is done. Otherwise, in some browsers, the website is blank white.

I do not see the point of not using setTimeOut() across all browsers. Keeps the code easier to maintain.