### PR TITLE
[WIP] Refactor config with nanostores

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
 		"@babel/core": "^7.12.0",
 		"@babel/plugin-transform-flow-strip-types": "^7.0.0",
 		"@parcel/config-webextension": "2.12.0",
+		"@types/chrome": "^0.0.316",
+		"@types/webextension-polyfill": "^0.12.3",
 		"autoprefixer": "10.4.20",
 		"concurrently": "9.0.1",
 		"flow-bin": "0.247.1",
@@ -48,7 +50,8 @@
 		"preact": "10.24.1",
 		"prettier": "^3.3.3",
 		"tailwindcss": "3.4.13",
-		"tailwindcss-cli": "0.1.2"
+		"tailwindcss-cli": "0.1.2",
+		"webextension-polyfill": "^0.12.0"
 	},
 	"dependencies": {
 		"@nanostores/preact": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -51,10 +51,12 @@
 		"tailwindcss-cli": "0.1.2"
 	},
 	"dependencies": {
+		"@nanostores/preact": "^1.0.0",
 		"easy-file-picker": "^1.1.0",
 		"fast-deep-equal": "^3.1.3",
 		"font-color-contrast": "^11.1.0",
 		"is-mobile": "^5.0.0",
+		"nanostores": "^1.0.1",
 		"rgb-hex": "^4.0.1"
 	},
 	"alias": {

--- a/src/content.js
+++ b/src/content.js
@@ -343,21 +343,22 @@ const initPage = () => {
 
 config.init().then(initPage);
 
-document.addEventListener('bga_ext_update_config', (data) => {
-	console.debug('[bga extension] configuration updated', data);
-	if (data.detail.key === 'hideGeneralChat') {
+window.addEventListener('storage', (data) => {
+	const key = data.key;
+	console.debug('[bga extension] configuration updated', key);
+	if (key === 'hideGeneralChat') {
 		setChatStyle(config);
-	} else if (data.detail.key === 'hideElo') {
+	} else if (key === 'hideElo') {
 		setEloStyle(config);
-	} else if (data.detail.key === 'muted') {
+	} else if (key === 'muted') {
 		refreshMutedPlayers(config);
-	} else if (data.detail.key === 'solidBack') {
+	} else if (key === 'solidBack') {
 		location.reload();
-	} else if (data.detail.key === 'inProgress' || data.detail.key === 'hideChatUserNames') {
+	} else if (key === 'inProgress' || key === 'hideChatUserNames') {
 		if (pageType === 'general') {
 			buildMainCss(config.getAllCss());
 		}
-	} else if (data.detail.key === 'home') {
+	} else if (key === 'home') {
 		localStorage.removeItem('bga-homepage-newsfeed-slots');
 		localStorage.removeItem('bga-homepageNewsSeen');
 
@@ -367,17 +368,17 @@ document.addEventListener('bga_ext_update_config', (data) => {
 		if (document.documentElement.classList.contains("bgaext_welcome")) {
 			sendHomeConfiguration();
 		}
-	} else if (data.detail.key === 'hideSocialMessages') {
+	} else if (key === 'hideSocialMessages') {
 		if (document.documentElement.classList.contains("bgaext_welcome") || document.documentElement.classList.contains("bgaext_player")) {
 			location.reload();
 		}
-	} else if (data.detail.key === 'animatedTitle') {
+	} else if (key === 'animatedTitle') {
 		if (config.isAnimatedTitle()) {
 			stopTitleObserver();
 		} else {
 			initTitleObserver();
 		}
-	} else if (['hideLogTimestamp', 'chatBarAutoHide'].includes(data.detail.key)) {
+	} else if (['hideLogTimestamp', 'chatBarAutoHide'].includes(key)) {
 		if (pageType === 'game') {
 			buildMainCss(config.getGameCss());
 
@@ -387,7 +388,7 @@ document.addEventListener('bga_ext_update_config', (data) => {
 				document.querySelector('body').removeEventListener('mousemove', autoHideChat);
 			}
 		}
-	} else if (data.detail.key === 'chatLightIcons') {
+	} else if (key === 'chatLightIcons') {
 		if (config.chatDarkIcons()) {
 			document.documentElement.classList.add('bgaext_chat_dark_icons');
 		} else {

--- a/src/contentForum.js
+++ b/src/contentForum.js
@@ -24,8 +24,8 @@ const initPage = () => {
   }
 };
 
-document.addEventListener('bga_ext_update_config', (data) => {
-  if (['darkModeColor', 'darkModeSat'].includes(data.detail.key)) {
+window.addEventListener('storage', (data) => {
+  if (['darkModeColor', 'darkModeSat'].includes(data.key)) {
     adjustDarkColors();
   }
 });

--- a/src/js/config/nanostores/storage.ts
+++ b/src/js/config/nanostores/storage.ts
@@ -1,0 +1,142 @@
+/**
+ * Modified implementation of PersistentMap from @nanostores/persistent to support Browser's Storage API
+*/
+
+import { task, map, onMount, type MapStore } from "nanostores";
+import { storage, type Storage } from "webextension-polyfill";
+
+export interface PersistentEvents {
+	addEventListener(
+		key: string,
+		callback: EventListener,
+		restore: () => void
+	): void
+	perKey?: boolean
+	removeEventListener(
+		key: string,
+		callback: EventListener,
+		restore: () => void
+	): void
+}
+
+let eventsEngine: PersistentEvents = { addEventListener() { }, removeEventListener() { } }
+type StorageEngine = Storage.StorageArea | Storage.StorageAreaWithUsage | undefined
+let storageEngine: StorageEngine
+
+export let windowPersistentEvents: PersistentEvents = {
+	addEventListener(key, listener, restore) {
+		window.addEventListener('storage', listener)
+		window.addEventListener('pageshow', restore)
+	},
+	removeEventListener(key, listener, restore) {
+		window.removeEventListener('storage', listener)
+		window.removeEventListener('pageshow', restore)
+	}
+}
+
+if (typeof window !== 'undefined') {
+	eventsEngine = windowPersistentEvents
+}
+
+if (storage && storage.local) {
+	storageEngine = storage.local
+}
+
+export function persistentMap<Value extends Record<string, any>>(prefix: string, initial: Value, storage?: StorageEngine): MapStore<Value> {
+	let encode = JSON.stringify
+	let decode = (encoded: string) => {
+		try {
+			return JSON.parse(encoded);
+		} catch (error) {
+			return encoded;
+		}
+	}
+
+	let _storageEngine = storage ?? storageEngine
+
+	let store = map<Record<string, any>>()
+
+	let setKey = store.setKey
+	let storeKey = (key: string, newValue: string | undefined) => {
+		if (typeof newValue === 'undefined') {
+			_storageEngine?.remove(key);
+		} else {
+			_storageEngine?.set({ [key]: encode(newValue) });
+		}
+	}
+
+	store.setKey = (key, newValue) => {
+		storeKey(key, newValue)
+		setKey(key, newValue)
+	}
+
+	let set = store.set
+	store.set = function (newObject) {
+		for (let key in newObject) {
+			storeKey(key, newObject[key])
+		}
+		for (let key in store.value) {
+			if (!(key in newObject)) {
+				storeKey(key, undefined)
+			}
+		}
+		set(newObject)
+	}
+
+	function listener(e: Event) {
+		const storageEvent = e as StorageEvent;
+		if (storageEvent?.storageArea?.getItem('prefix') !== prefix) {
+			return
+		}
+
+		const key = storageEvent.key
+
+		if (!key) {
+			set({})
+		} else {
+			const value = storageEvent.newValue
+			if (value === null) {
+				setKey(key, undefined)
+			} else {
+				setKey(key, decode(value))
+			}
+		}
+	}
+
+	async function restore() {
+		if (!_storageEngine) {
+			return
+		}
+
+		_storageEngine.set({ 'prefix': prefix });
+
+		let storage: Record<string, string> = {}
+		try {
+			storage = await _storageEngine.get() as Record<string, string>;
+		} catch (error) {
+			console.error('[bga-ext] Failed to restore storage', error)
+		}
+
+		const data: Record<string, any> = { ...initial }
+		for (let key in storage) {
+			data[key] = decode(storage[key])
+		}
+
+		for (let key of Object.keys(data)) {
+			store.setKey(key, data[key])
+		}
+	}
+
+	onMount(store, () => {
+		task(async () => {
+			await restore();
+		})
+
+		eventsEngine.addEventListener(prefix, listener, restore)
+		return () => {
+			eventsEngine.removeEventListener(prefix, listener, restore)
+		}
+	})
+
+	return store as MapStore<Value>
+}

--- a/src/js/ui/content/rightMenu/RightMenu.tsx
+++ b/src/js/ui/content/rightMenu/RightMenu.tsx
@@ -74,12 +74,12 @@ const RightMenu = (props: RightMenuProps) => {
 		window.addEventListener("resize", setMenuPosition);
 		window.addEventListener("scroll", setMenuPosition);
 		document.addEventListener("click", onClick);
-		document.addEventListener("bga_ext_update_config", onUpdateConfig);
+		window.addEventListener("storage", onUpdateConfig);
 		return () => {
 			window.removeEventListener("resize", setMenuPosition);
 			window.removeEventListener("scroll", setMenuPosition);
 			document.removeEventListener("click", onClick);
-			document.removeEventListener("bga_ext_update_config", onUpdateConfig);
+			window.removeEventListener("storage", onUpdateConfig);
 		};
 	});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,6 +1144,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
 
+"@types/webextension-polyfill@^0.12.3":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@types/webextension-polyfill/-/webextension-polyfill-0.12.3.tgz#a4ac3452b816e4bd646024007a886234e2f6293e"
+  integrity sha512-F58aDVSeN/MjUGazXo/cPsmR76EvqQhQ1v4x23hFjUX0cfAJYE+JBWwiOGW36/VJGGxoH74sVlRIF3z7SJCKyg==
+
 abortcontroller-polyfill@^1.1.9:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz#6738495f4e901fbb57b6c0611d0c75f76c485bed"
@@ -2975,6 +2980,11 @@ weak-lru-cache@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
   integrity sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==
+
+webextension-polyfill@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz#f62c57d2cd42524e9fbdcee494c034cae34a3d69"
+  integrity sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==
 
 which@^2.0.1:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,6 +312,11 @@
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz#0aa5502d547b57abfc4ac492de68e2006e417242"
   integrity sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==
 
+"@nanostores/preact@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@nanostores/preact/-/preact-1.0.0.tgz#23d89d39e09d377f53e3d9aaa35a11270bc4d5a5"
+  integrity sha512-woHYvSwau1YtO9AEnGsh/jRPU2u5DTfNSrDHtKMZOeDUWV6EJfvyv7dJ7AaMps2I9uJcY6OlqXKkA9qTctEjyw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2226,6 +2231,11 @@ nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+
+nanostores@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nanostores/-/nanostores-1.0.1.tgz#bcc352ff7bf622e9274a3109c92e823a452d6028"
+  integrity sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==
 
 node-addon-api@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
Goal: Improve handling of stored config value by utilizing nanostores.

This is still a work in progress. But wanted to share the current state

To-dos:
- [ ] Integrate stores directly with UI elements via useStore() hooks
- [ ] Split config into submodules / subclasses (better tree-shaking support, smaller bundle size)
- [ ] Fully support lazy store/loading behavior (aka only mount stores when needed)
- [ ] (Maybe) Use session storage as cache
- [ ] Cleanup code