### PR TITLE
Fix: game title counter null checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 			"sourceMap": {
 				"inline": true,
 				"inlineSources": true
-			}
+			},
+			"optimize": false
 		},
 		"prod": {},
 		"prod-firefox": {},

--- a/src/js/ui/content/functions.js
+++ b/src/js/ui/content/functions.js
@@ -390,6 +390,10 @@ export const initGamePanelObserver = () => {
 
 		if (!counter) {
 			const titleContainer = gaminfoElt.querySelector('.bga-page-section__title');
+			if (!titleContainer) {
+				return;
+			}
+
 			counter = document.createElement("span");
 			counter.id = counterId;
 			titleContainer.appendChild(counter);


### PR DESCRIPTION
The title container may be null if the game title objects are still
loading. Caused various issues by breaking the whole content update
routine.

Also turned off optimization for the dev build to speed up debugging the content scripts.

We may want to convert all critical routines to typescript long term to
avoid issues like these