### PR TITLE
Kingscraft dark theme fix

### DIFF
--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -230,10 +230,10 @@
 		"message": "Son par défaut"
 	},
 	"optionsFlashingOn": {
-		"message": "Les tables sur lesquels vous êtes attendus sont signalées par une couleur clignotante"
+		"message": "Les tables sur lesquelles vous êtes attendu sont signalées par une couleur clignotante"
 	},
 	"optionsFlashingOff": {
-		"message": "Les tables sur lesquels vous êtes attendus sont signalées par un code couleur et un message"
+		"message": "Les tables sur lesquelles vous êtes attendu sont signalées par un code couleur et un message"
 	},
 	"optionsLobbyRedirectOn": {
 		"message": "Les hyperliens du site sont modifiés pour pointer vers le lobby classique (lorsque c'est possible)"

--- a/src/js/config/darkThemeGames.ts
+++ b/src/js/config/darkThemeGames.ts
@@ -4099,6 +4099,7 @@ _darkStyleForGame['kingscraft'] = `
 .player-name { background-color: var(--dark-20) !important; }
 button.enhance .text, button.trade .text, .midSizeDialog div[style*="border-radius: 10px"] { color: #000; }
 button.enhance:disabled .text, button.trade:disabled .text { color: var(--dark-40); }
+button.switch, .check { background: black!important }
 `;
 
 _darkStyleForGame['klaverjassen'] = `


### PR DESCRIPTION
Button to use a potion (`button.switch`) and Confirm/Cancel buttons (`.check`) when selling items/potions now have a dark background (both had white text on white background)