### PR TITLE
fix: Ensure table icons stay clickable

### DIFF
--- a/src/js/ui/Table.tsx
+++ b/src/js/ui/Table.tsx
@@ -10,7 +10,6 @@ import { TableIcons } from "./TableIcons.jsx";
 import { TableIndicator } from "./TableIndicator";
 import { Card } from "./base/Card";
 import { ClickableTableIcon } from "./ClickableTableIcon";
-import { url } from "inspector";
 
 type Props = {
 	tableId: TableId,

--- a/src/js/ui/TableIcons.tsx
+++ b/src/js/ui/TableIcons.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export function TableIcons({ children }: Props) {
 	return (
-		<div class="absolute flex right-1 top-1 gap-1 text-xs opacity-80">
+		<div class="absolute flex right-1 top-1 gap-1 text-xs opacity-80 z-10">
 			{children}
 		</div>
 	);


### PR DESCRIPTION
For tables where the player is not the active one the table icons become not clickable due to the background being at z-index 1