### PR TITLE
tweak: parcel transformer for darkstyle html context

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -6,6 +6,10 @@
     ],
     "*.{ts,tsx}": [
       "@parcel/transformer-typescript-tsc"
+    ],
+    "*.less": [
+      "./src/libs/parcel/parcel-transformer-replace-darkmode-context.js",
+      "..."
     ]
   }
 }

--- a/src/js/ui/content/darkMode/darkStyleFunctions.ts
+++ b/src/js/ui/content/darkMode/darkStyleFunctions.ts
@@ -57,7 +57,7 @@ _init().then(() => {
 
     getFile(gameStyleFile, true).then(fileContent => {
       const { file, content } = fileContent;
-      cssContents[file] = content.replace(/#D(?=[ .:])/g, 'html[data-theme=dark]');
+      cssContents[file] = content;
       gameStyleComponent.innerHTML = cssContents[file];
     });
   }

--- a/src/libs/parcel/parcel-transformer-replace-darkmode-context.js
+++ b/src/libs/parcel/parcel-transformer-replace-darkmode-context.js
@@ -1,0 +1,10 @@
+const {Transformer} = require('@parcel/plugin');
+
+module.exports = new Transformer({
+  async transform({asset}) {
+	let code = await asset.getCode();
+	code = code.replace(/#D(?=[ .:])/g, 'html[data-theme=dark]')
+	asset.setCode(code);
+	return [asset];
+  }
+});


### PR DESCRIPTION
Use transformer during build time instead of during runtime to apply the proper html darkstyle context.

Makes it slightly easier to debug game styles as you can directly edit the css artifacts