### PR TITLE
Option to hide beginner status message in player panels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,7 @@
     "editor.tabSize": 4,
     "diffEditor.ignoreTrimWhitespace": true,
     "editor.formatOnSave": true,
-    "javascript.preferences.quoteStyle": "double",
-    "typescript.preferences.quoteStyle": "double",
+    "js/ts.preferences.quoteStyle": "double",
     "files.trimTrailingWhitespace": true,
     "files.exclude": {
         "node_modules": true,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@parcel/transformer-less": "2.16.4",
 		"@parcel/transformer-typescript-tsc": "2.16.4",
 		"@tailwindcss/cli": "^4.1.17",
-		"@types/chrome": "0.1.37",
+		"@types/chrome": "^0.1.37",
 		"@types/node": "24.10.15",
 		"autoprefixer": "10.4.27",
 		"concurrently": "9.2.1",

--- a/src/content.ts
+++ b/src/content.ts
@@ -20,6 +20,7 @@ import {
 	initChatIcon,
 	setChatStyle,
 	setEloStyle,
+    setBeginnerStatusStyle,
 	initDarkMode,
 	refreshMutedPlayers,
 	displayInformationPopup
@@ -323,6 +324,7 @@ const initPage = () => {
 		document.head.appendChild(script);
 
 		setEloStyle(config);
+		setBeginnerStatusStyle(config);
 	});
 
 	waitForObj('body').then(() => {
@@ -391,7 +393,9 @@ document.addEventListener('bga_ext_update_config', (data) => {
 		setChatStyle(config);
 	} else if (key === 'hideElo' || key === 'hideArenaElo') {
 		setEloStyle(config);
-	} else if (key === 'muted') {
+	} else if (key === 'hideBeginnerStatus') {
+        setBeginnerStatusStyle(config);
+    } else if (key === 'muted') {
 		refreshMutedPlayers(config);
 	} else if (key === 'solidBack') {
 		location.reload();

--- a/src/js/config/configuration.ts
+++ b/src/js/config/configuration.ts
@@ -19,6 +19,7 @@ interface CustomConfig {
 	hideGeneralChat?: boolean;
 	hideElo?: boolean;
 	hideArenaElo?: boolean;
+	hideBeginnerStatus?: boolean;
 	darkMode?: boolean;
 	darkModeColor?: number;
 	darkModeSat?: number;
@@ -656,6 +657,10 @@ class Configuration {
 		return this._customConfig.hideArenaElo !== false;
 	}
 
+    isBeginnerStatusHidden() {
+		return this._customConfig.hideBeginnerStatus === true;
+	}
+
 	setEloHidden(val: boolean) {
 		this._customConfig.hideElo = val;
 		storageSet({ hideElo: val });
@@ -666,6 +671,11 @@ class Configuration {
 		storageSet({ hideArenaElo: val });
 	}
 
+	setBeginnerStatusHidden(val: boolean) {
+		this._customConfig.hideBeginnerStatus = val;
+		storageSet({ hideBeginnerStatus: val });
+	}
+
 	getEloStyle() {
 		let eloStyle = '';
 
@@ -673,8 +683,7 @@ class Configuration {
 			eloStyle += '.player_elo_wrap, #game_result .adddetails, #table_stats .row-data:has(> .row-value > .gamerank) { display: none; } '
 		}
 
-		const showArenaElo = !this.isArenaEloHidden();
-		if (showArenaElo) {
+		if (!this.isArenaEloHidden()) {
 			eloStyle += '.arena_mode .player_elo_wrap { visibility: visible; display: inline; } '
 		}
 

--- a/src/js/ui/content/functions.tsx
+++ b/src/js/ui/content/functions.tsx
@@ -697,6 +697,10 @@ const setEloStyle = (config: Configuration) => {
 	setStyle('bgaext-elo-style', config.getEloStyle());
 };
 
+const setBeginnerStatusStyle = (config: Configuration) => {
+	setStyle('bgaext-beginner-status-style', config.isBeginnerStatusHidden() ? '.doubletime_infos { display: none; }' : '');
+};
+
 export {
 	buildMainCss,
 	initGamesObserver,
@@ -712,6 +716,7 @@ export {
 	initChatIcon,
 	setChatStyle,
 	setEloStyle,
+    setBeginnerStatusStyle,
 	initDarkMode,
 	displayInformationPopup
 };

--- a/src/js/ui/views/OptionsView.tsx
+++ b/src/js/ui/views/OptionsView.tsx
@@ -26,6 +26,7 @@ export const OptionsView = ({ config, onChange }: Props) => {
   const [autoClickStart, setAutoClickStart] = useSyncedState('autoClickStart', config.autoClickStart());
   const [eloHidden, setEloHidden] = useSyncedState('eloHidden', config.isEloHidden());
   const [arenaEloHidden, setArenaEloHidden] = useSyncedState('arenaEloHidden', config.isArenaEloHidden());
+  const [beginnerStatusHidden, setBeginnerStatusHidden] = useSyncedState('beginnerStatusHidden', config.isBeginnerStatusHidden());
   const [tracking, setTracking] = useSyncedState('tracking', config.isTrackingEnable());
   const [soundNotification, setSoundNotification] = useSyncedState('soundNotification', config.isSoundNotificationEnable());
   const [customSoundFile, setCustomSoundFile] = useSyncedState('customSoundFile', isSoundCustom());
@@ -111,6 +112,11 @@ export const OptionsView = ({ config, onChange }: Props) => {
   const updateArenaEloHidden = (val: boolean) => {
     setArenaEloHidden(!val);
     config.setArenaEloHidden(!val)
+  };
+  
+  const updateBeginnerStatusHidden = (val: boolean) => {
+    setBeginnerStatusHidden(!val);
+    config.setBeginnerStatusHidden(!val)
   };
 
   const updateAnimatedTitle = (val: boolean) => {
@@ -418,6 +424,7 @@ export const OptionsView = ({ config, onChange }: Props) => {
           {getSwitch(onlineMessages, updateOnlineMessages, "optionFriendsActivityOn", "optionFriendsActivityOff")}
           {getSwitch(!eloHidden, updateEloHidden, "optionEloHiddenOff", "optionEloHiddenOn")}
           {getSwitch(!arenaEloHidden, updateArenaEloHidden, "optionArenaEloHiddenOff", "optionArenaEloHiddenOn")}
+          {getSwitch(!beginnerStatusHidden, updateBeginnerStatusHidden, "optionBeginnerStatusHiddenOff", "optionBeginnerStatusHiddenOn")}
           {desktopVersion && getSwitch(chatBarAutoHide, updateChatBarAutoHide, "optionsChatAutoHideOn", "optionsChatAutoHideOff")}
           {getSwitch(areLogTimestampsHidden, updateAreLogTimestampsRemoved, "optionRemoveLogTimestampsOn", "optionRemoveLogTimestampsOff")}
           {getSwitch(!hideLeftBarOption, updateHideLeftBarOption, "optionHideLeftBarOptionOff", "optionHideLeftBarOptionOn")}

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -26,6 +26,8 @@
   "optionEloHiddenOff": "Les puntuacions ELO dels jugadors es mostren en partides normals (comportament predeterminat)",
   "optionArenaEloHiddenOn": "Les puntuacions ELO dels jugadors estan ocultes en partides d'arena (comportament predeterminat)",
   "optionArenaEloHiddenOff": "Les puntuacions ELO dels jugadors es mostren en partides d'arena",
+  "optionBeginnerStatusHiddenOn": "The beginner message in player panels is hidden",
+  "optionBeginnerStatusHiddenOff": "The beginner message in player panels is visible",
   "optionLeftMenu": "Navegar entre els taulers dels jugadors",
   "optionHideLeftBarOptionOn": "La barra vertical per navegar entre taulers de jugadors està desactivada per a tots els jocs",
   "optionHideLeftBarOptionOff": "S'afegeix automàticament una barra vertical per navegar entre taulers de jugadors en els jocs compatibles. Aquesta barra es pot desactivar a les preferències del joc",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -26,6 +26,8 @@
   "optionEloHiddenOff": "Der ELO-Wert der Spieler wird in normalen Spielen angezeigt (Standardverhalten)",
   "optionArenaEloHiddenOn": "Der ELO-Wert der Spieler wird in Arena-Spielen ausgeblendet (Standardverhalten)",
   "optionArenaEloHiddenOff": "Der ELO-Wert der Spieler wird in Arena-Spielen angezeigt",
+  "optionBeginnerStatusHiddenOn": "The beginner message in player panels is hidden",
+  "optionBeginnerStatusHiddenOff": "The beginner message in player panels is visible",
   "optionLeftMenu": "Navigiere zwischen den Spieler Bereichen",
   "optionHideLeftBarOptionOn": "Das Spieler-Bereiche-Naivigations-Menü ist deaktiviert",
   "optionHideLeftBarOptionOff": "Das Spieler-Bereiche-Navigation-Menü wird zu kompatiblen Spielen hinzugefügt. Es kann in den jeweiligen Spiele-Einstellungen deaktiviert werden",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,6 +26,8 @@
   "optionEloHiddenOff": "Players' ELO scores are displayed in normal games (default behavior)",
   "optionArenaEloHiddenOn": "Players' ELO scores are hidden in arena games (default behavior)",
   "optionArenaEloHiddenOff": "Players' ELO scores are displayed in arena games",
+  "optionBeginnerStatusHiddenOn": "The beginner message in player panels is hidden",
+  "optionBeginnerStatusHiddenOff": "The beginner message in player panels is visible",
   "optionLeftMenu": "Navigate between players' boards",
   "optionHideLeftBarOptionOn": "The vertical bar for navigating between player boards is disabled for all games",
   "optionHideLeftBarOptionOff": "A vertical bar for navigating between player boards is added automatically for compatible games. This bar can be deactivated in the game preferences",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -26,6 +26,8 @@
   "optionEloHiddenOff": "Las puntuaciones ELO de los jugadores se muestran en partidas normales (comportamiento predeterminado)",
   "optionArenaEloHiddenOn": "Las puntuaciones ELO de los jugadores están ocultas en partidas de arena (comportamiento predeterminado)",
   "optionArenaEloHiddenOff": "Las puntuaciones ELO de los jugadores se muestran en partidas de arena",
+  "optionBeginnerStatusHiddenOn": "The beginner message in player panels is hidden",
+  "optionBeginnerStatusHiddenOff": "The beginner message in player panels is visible",
   "optionLeftMenu": "Navegar entre los tableros de los jugadores",
   "optionHideLeftBarOptionOn": "La barra vertical para navegar entre tableros de jugadores está desactivada para todos los juegos",
   "optionHideLeftBarOptionOff": "Se añade automáticamente una barra vertical para navegar entre tableros de jugadores en los juegos compatibles. Esta barra se puede desactivar en las preferencias del juego",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -26,6 +26,8 @@
   "optionEloHiddenOff": "Le score ELO des joueurs est affiché dans les jeux en mode 'Partie simple' (comportement par défaut)",
   "optionArenaEloHiddenOn": "Le score ELO des joueurs est caché dans les jeux en mode 'Arène' (comportement par défaut)",
   "optionArenaEloHiddenOff": "Le score ELO des joueurs est affiché dans les jeux en mode 'Arène'",
+  "optionBeginnerStatusHiddenOn": "Le message pour les débutants dans les panneaux de joueur est masqué",
+  "optionBeginnerStatusHiddenOff": "Le message pour les débutants dans les panneaux de joueur est visible",
   "optionLeftMenu": "Naviguer entre les plateaux des joueurs",
   "optionHideLeftBarOptionOn": "La barre verticale permettant de naviguer entre les plateaux des joueurs est désactivée pour tous les jeux",
   "optionHideLeftBarOptionOff": "Une barre verticale permettant de naviguer entre les plateaux des joueurs est ajoutée automatiquement pour les jeux compatibles. Cette barre est désactivable dans les préférences des jeux",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -26,6 +26,8 @@
   "optionEloHiddenOff": "通常のゲームでプレイヤーのELOスコアを表示します（デフォルトの動作）",
   "optionArenaEloHiddenOn": "アリーナゲームモードでプレイヤーのELOスコアを表示しません（デフォルトの動作）",
   "optionArenaEloHiddenOff": "アリーナゲームモードでプレイヤーのELOスコアを表示します",
+  "optionBeginnerStatusHiddenOn": "The beginner message in player panels is hidden",
+  "optionBeginnerStatusHiddenOff": "The beginner message in player panels is visible",
   "optionLeftMenu": "プレイヤーのボード間を移動するメニューの表示",
   "optionHideLeftBarOptionOn": "プレイヤーのボード間を移動するためのメニューは、すべてのゲームで無効化されています",
   "optionHideLeftBarOptionOff": "互換性のあるゲームでは、プレイヤーのボード間を移動するためのメニューが自動的に追加されます。このメニューはゲーム設定で無効化できます。",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,9 @@
     "typeRoots": [
       "./node_modules/@types"
     ],
+    "types": [
+      "chrome"
+    ]
   },
   // Only include explicit typescript files as other files (.js or .jsx) use mostly using flow
   "include": [


### PR DESCRIPTION
Adds an option to remove this message from player panels:

> This is my first game, so my turn time is doubled
> Thanks for helping me!

Also some misc cleanup, fixing the errors (thus providing proper typing for) `chrome.` stuff and replacing deprecated quoteStyle settings from settings.json